### PR TITLE
100% type coverage and fixes from static analysis

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
         }
     ],
     "require": {
-        "php" : "^7.1 || ^8.0"
+        "php" : "^7.1 || ^8.0",
+        "symfony/polyfill-php80": "^1.17"
     },
     "require-dev": {
         "phpunit/phpunit" : "^7.5.15 || ^8.5 || ^9.3"

--- a/tests/UriTemplateTest.php
+++ b/tests/UriTemplateTest.php
@@ -20,7 +20,7 @@ final class UriTemplateTest extends TestCase
             'empty' => '',
             'path'  => '/foo/bar',
             'x'     => '1024',
-            'y'     => '768',
+            'y'     => 768,
             'null'  => null,
             'list'  => ['red', 'green', 'blue'],
             'keys'  => [


### PR DESCRIPTION
1. Make sure UriTemplate::expand() returns a string. This is certainly what any user of the package would want!
2. Added 100% type coverage and fixed the type errors pointed out by phpstan.