### PR TITLE
Make sure UriTemplate::expand() returns a string

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
         }
     ],
     "require": {
-        "php" : "^7.1 || ^8.0"
+        "php" : "^7.1 || ^8.0",
+        "symfony/polyfill-php80": "^1.17"
     },
     "require-dev": {
         "phpunit/phpunit" : "^7.5.15 || ^8.5 || ^9.3"

--- a/src/UriTemplate.php
+++ b/src/UriTemplate.php
@@ -76,19 +76,26 @@ final class UriTemplate
     /**
      * @param mixed[] $variables Variables to use in the template expansion
      *
-     * @return string|string[]|null
+     * @throws \RuntimeException
      */
-    public static function expand(string $template, array $variables)
+    public static function expand(string $template, array $variables): string
     {
         if (false === \strpos($template, '{')) {
             return $template;
         }
 
-        return \preg_replace_callback(
+        /** @var string|null */
+        $result = \preg_replace_callback(
             '/\{([^\}]+)\}/',
             self::expandMatchCallback($variables),
             $template
         );
+
+        if (null === $result) {
+            throw new \RuntimeException(\sprintf('Unable to process template: %s', \preg_last_error_msg()));
+        }
+
+        return $result;
     }
 
     /**


### PR DESCRIPTION
It could never have returned `string[]`. I assume that change was incorrectly advised by phpstan. We should actually say we return a string, and fail loudly if replacement fails due to some internal preg error. This is going to be what consumers of this code expect. The old return type would have made the library horrible to use, having to check if the template returned a string or not, each time!