### PR TITLE
RFC 6570 compliance for positive cases

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,12 +16,26 @@
             "role": "Developer"
         }
     ],
+    "repositories": [
+        {
+            "type": "package",
+            "package": {
+                "name": "uri-template/tests",
+                "version": "1.0.0",
+                "dist": {
+                    "url": "https://github.com/uri-templates/uritemplate-test/archive/520fdd8b0f78779d12178c357a986e0e727f4bd0.zip",
+                    "type": "zip"
+                }
+            }
+        }
+    ],
     "require": {
         "php" : "^7.1 || ^8.0",
         "symfony/polyfill-php80": "^1.17"
     },
     "require-dev": {
-        "phpunit/phpunit" : "^7.5.15 || ^8.5 || ^9.3"
+        "phpunit/phpunit" : "^7.5.15 || ^8.5 || ^9.3",
+        "uri-template/tests": "1.0.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/UriTemplate.php
+++ b/src/UriTemplate.php
@@ -125,6 +125,7 @@ final class UriTemplate
         $prefix = self::$operatorHash[$parsed['operator']]['prefix'];
         $joiner = self::$operatorHash[$parsed['operator']]['joiner'];
         $useQuery = self::$operatorHash[$parsed['operator']]['query'];
+        $allUndefined = true;
 
         foreach ($parsed['values'] as $value) {
             if (!isset($variables[$value['value']])) {
@@ -194,6 +195,7 @@ final class UriTemplate
                     $expanded = \implode(',', $kvp);
                 }
             } else {
+                $allUndefined = false;
                 if ($value['modifier'] === ':' && isset($value['position'])) {
                     $variable = \substr((string) $variable, 0, $value['position']);
                 }
@@ -215,8 +217,16 @@ final class UriTemplate
         }
 
         $ret = \implode($joiner, $replacements);
-        if ($ret && $prefix) {
-            return \sprintf('%s%s', $prefix, $ret);
+
+        if ('' === $ret) {
+            // Spec section 3.2.4 and 3.2.5
+            if (false === $allUndefined && ('#' === $prefix || '.' === $prefix)) {
+                return $prefix;
+            }
+        } else {
+            if ('' !== $prefix) {
+                return \sprintf('%s%s', $prefix, $ret);
+            }
         }
 
         return $ret;


### PR DESCRIPTION
This tests against all the positive examples in the spec. The spec also says that the implementation should hard fail when the input template has invalid syntax (negative examples). We do not currently do that, and I consider testing for that out of scope of this PR.

---

Depends on https://github.com/guzzle/uri-template/pull/6. Closes https://github.com/guzzle/uri-template/issues/9.