### PR TITLE
0 should be allowed as an expanded value

### DIFF
--- a/src/UriTemplate.php
+++ b/src/UriTemplate.php
@@ -206,7 +206,7 @@ final class UriTemplate
             }
 
             if ($actuallyUseQuery) {
-                if (!$expanded && $joiner !== '&') {
+                if ($expanded === '' && $joiner !== '&') {
                     $expanded = $value['value'];
                 } else {
                     $expanded = \sprintf('%s=%s', $value['value'], $expanded);

--- a/tests/UriTemplateTest.php
+++ b/tests/UriTemplateTest.php
@@ -22,6 +22,7 @@ final class UriTemplateTest extends TestCase
             'x' => '1024',
             'y' => 768,
             'null' => null,
+            'zero' => 0,
             'list' => ['red', 'green', 'blue'],
             'keys' => [
                 'semi' => ';',
@@ -56,6 +57,7 @@ final class UriTemplateTest extends TestCase
                ['{/var}',              '/value'],
                ['{/var,x}/here',       '/value/1024/here'],
                ['{;x,y}',              ';x=1024;y=768'],
+               ['{;zero}',             ';zero=0'],
                ['{;x,y,empty}',        ';x=1024;y=768;empty'],
                ['{?x,y}',              '?x=1024&y=768'],
                ['{?x,y,empty}',        '?x=1024&y=768&empty='],


### PR DESCRIPTION
This fixes an issue where `0` value is being ignored when trying to expand a simple template such as `http://www.test.com{;zero}`

Previously `'http://www.test.com{;zero}` with `zero=0` would expand to `http://www.test.com;zero`
After the proposed change it would expand to `http://www.test.com;zero=0`
