### PR TITLE
Run static analysis on PHP 7.4

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.5'
+          php-version: '7.4'
           coverage: none
           extensions: mbstring, intl
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -17,15 +17,3 @@ parameters:
 			identifier: missingType.iterableValue
 			count: 1
 			path: src/UriTemplate.php
-
-		-
-			message: '#^Parameter \#1 \$matches of static method GuzzleHttp\\UriTemplate\\UriTemplate\:\:expandMatch\(\) expects array\<string\>, array given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/UriTemplate.php
-
-		-
-			message: '#^Parameter \#3 \.\.\.\$values of function sprintf expects bool\|float\|int\|string\|null, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/UriTemplate.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -3,6 +3,6 @@ includes:
     - vendor-bin/phpstan/vendor/phpstan/phpstan-deprecation-rules/rules.neon
 
 parameters:
-    level: max
+    level: 9
     paths:
         - src

--- a/vendor-bin/phpstan/composer.json
+++ b/vendor-bin/phpstan/composer.json
@@ -1,6 +1,6 @@
 {
     "require": {
-        "php": "^8.2",
+        "php": "^7.4",
         "phpstan/phpstan": "2.1.55",
         "phpstan/phpstan-deprecation-rules": "2.0.4"
     },


### PR DESCRIPTION
Runs the PHPStan static job on PHP 7.4 and lowers the isolated PHPStan tool manifest PHP constraint to ^7.4 so all static tooling runs consistently on PHP 7.4.