### PR TITLE
Drop PHP 7.2 and 7.3 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.2'
+          php-version: '7.4'
           ini-values: error_reporting=E_ALL
           coverage: 'none'
           extensions: mbstring
@@ -38,7 +38,7 @@ jobs:
       fail-fast: false
       max-parallel: 10
       matrix:
-        php: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
+        php: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
 
     steps:
       - name: Set up PHP

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to `uri-template` will be documented in this file.
 
 Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) principles.
 
+## v2.0.0 - Unreleased
+
+### Removed
+- Dropped support for PHP 7.2 and 7.3
+
 ## v1.0.5 - 2025-08-22
 
 ### Changed

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,13 @@
+Guzzle URI Template Upgrade Guide
+=================================
+
+1.x to 2.0
+----------
+
+#### PHP Version and Dependencies
+
+Guzzle URI Template 2.0 requires PHP `^7.4 || ^8.0`. Guzzle URI Template 1.x
+supported PHP `^7.2.5 || ^8.0`.
+
+If your application still supports PHP 7.2 or 7.3, continue using Guzzle URI
+Template 1.x until your minimum PHP version is raised.

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         }
     ],
     "require": {
-        "php": "^7.2.5 || ^8.0",
+        "php": "^7.4 || ^8.0",
         "symfony/polyfill-php80": "^1.24"
     },
     "require-dev": {


### PR DESCRIPTION
This raises the 2.0 branch PHP requirement to PHP ^7.4 || ^8.0 and updates CI so the lowest dependency build and test matrix start at PHP 7.4. It also adds an upgrade guide for applications moving from 1.x to 2.0 and records the upcoming 2.0.0 support change in the changelog.

Verified on PHP 7.4 with PHPUnit, PHPStan, PHP-CS-Fixer dry run, and composer-normalize.