### PR TITLE
Link upgrade guide from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ $ composer require guzzlehttp/uri-template
 
 Please see [CHANGELOG](CHANGELOG.md) for more information on what has changed recently.
 
+Please see [UPGRADING](UPGRADING.md) for details on upgrading to new major versions.
+
 ## Testing
 
 ``` bash


### PR DESCRIPTION
This adds a README link to the upgrade guide so users can find the 2.0 upgrade notes from the project landing page.

Docs-only change; no tests were run.