### PR TITLE
Add strict validation test helpers

### DIFF
--- a/tests/UriTemplateTest.php
+++ b/tests/UriTemplateTest.php
@@ -123,7 +123,7 @@ final class UriTemplateTest extends TestCase
      */
     public function testExpandsUriTemplates(string $template, string $expansion, array $variables): void
     {
-        self::assertSame($expansion, self::expandWithoutPhpWarnings($template, $variables));
+        self::assertSame($expansion, UriTemplate::expand($template, $variables));
     }
 
     public static function expressionProvider(): array
@@ -185,7 +185,7 @@ final class UriTemplateTest extends TestCase
      */
     public function testAllowsNestedArrayExpansion(): void
     {
-        $result = self::expandWithoutPhpWarnings('http://example.com{+path}{/segments}{?query,data*,foo*}', [
+        $result = UriTemplate::expand('http://example.com{+path}{/segments}{?query,data*,foo*}', [
             'path' => '/foo/bar',
             'segments' => ['one', 'two'],
             'query' => 'test',
@@ -218,7 +218,7 @@ final class UriTemplateTest extends TestCase
      */
     public function testSpecCompliance(string $template, array $expansions, array $variables): void
     {
-        self::assertContains(self::expandWithoutPhpWarnings($template, $variables), $expansions);
+        self::assertContains(UriTemplate::expand($template, $variables), $expansions);
     }
 
     private static function parseSpecExamples(string $filename): \Generator
@@ -231,40 +231,11 @@ final class UriTemplateTest extends TestCase
         }
     }
 
-    private static function expandWithoutPhpWarnings(string $template, array $variables): string
-    {
-        $result = null;
-
-        self::withoutPhpWarnings(static function () use ($template, $variables, &$result): void {
-            $result = UriTemplate::expand($template, $variables);
-        });
-
-        self::assertIsString($result);
-
-        return $result;
-    }
-
     private function assertInvalidTemplate(string $template, array $variables = []): void
     {
         $this->expectException(\InvalidArgumentException::class);
 
         UriTemplate::expand($template, $variables);
-    }
-
-    /**
-     * @param callable():void $callback
-     */
-    private static function withoutPhpWarnings(callable $callback): void
-    {
-        \set_error_handler(static function (int $severity, string $message, string $file, int $line): void {
-            throw new \ErrorException($message, 0, $severity, $file, $line);
-        });
-
-        try {
-            $callback();
-        } finally {
-            \restore_error_handler();
-        }
     }
 
     public static function invalidSpecProvider(): \Generator

--- a/tests/UriTemplateTest.php
+++ b/tests/UriTemplateTest.php
@@ -223,13 +223,61 @@ final class UriTemplateTest extends TestCase
 
     private static function parseSpecExamples(string $filename): \Generator
     {
-        $examples = \file_get_contents(\sprintf('%s/../vendor/uri-template/tests/%s', __DIR__, $filename));
-
-        foreach (\json_decode($examples, true) as $example) {
+        foreach (self::loadSpecFixture($filename) as $example) {
             $variables = $example['variables'];
             foreach ($example['testcases'] as $case) {
                 yield [$case[0], (array) $case[1], $variables];
             }
         }
+    }
+
+    private function assertInvalidTemplate(string $template, array $variables = []): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        UriTemplate::expand($template, $variables);
+    }
+
+    /**
+     * @param callable():void $callback
+     */
+    private static function withoutPhpWarnings(callable $callback): void
+    {
+        \set_error_handler(static function (int $severity, string $message, string $file, int $line): void {
+            throw new \ErrorException($message, 0, $severity, $file, $line);
+        });
+
+        try {
+            $callback();
+        } finally {
+            \restore_error_handler();
+        }
+    }
+
+    public static function invalidSpecProvider(): \Generator
+    {
+        foreach (self::loadSpecFixture('negative-tests.json') as $groupName => $group) {
+            foreach ($group['testcases'] as $index => $case) {
+                if ($case[1] !== false) {
+                    continue;
+                }
+
+                yield \sprintf('%s #%d %s', $groupName, $index, $case[0]) => [
+                    $case[0],
+                    $group['variables'],
+                ];
+            }
+        }
+    }
+
+    private static function loadSpecFixture(string $filename): array
+    {
+        $contents = \file_get_contents(\sprintf('%s/../vendor/uri-template/tests/%s', __DIR__, $filename));
+        self::assertIsString($contents);
+
+        $decoded = \json_decode($contents, true);
+        self::assertIsArray($decoded);
+
+        return $decoded;
     }
 }

--- a/tests/UriTemplateTest.php
+++ b/tests/UriTemplateTest.php
@@ -123,7 +123,7 @@ final class UriTemplateTest extends TestCase
      */
     public function testExpandsUriTemplates(string $template, string $expansion, array $variables): void
     {
-        self::assertSame($expansion, UriTemplate::expand($template, $variables));
+        self::assertSame($expansion, self::expandWithoutPhpWarnings($template, $variables));
     }
 
     public static function expressionProvider(): array
@@ -185,7 +185,7 @@ final class UriTemplateTest extends TestCase
      */
     public function testAllowsNestedArrayExpansion(): void
     {
-        $result = UriTemplate::expand('http://example.com{+path}{/segments}{?query,data*,foo*}', [
+        $result = self::expandWithoutPhpWarnings('http://example.com{+path}{/segments}{?query,data*,foo*}', [
             'path' => '/foo/bar',
             'segments' => ['one', 'two'],
             'query' => 'test',
@@ -218,7 +218,7 @@ final class UriTemplateTest extends TestCase
      */
     public function testSpecCompliance(string $template, array $expansions, array $variables): void
     {
-        self::assertContains(UriTemplate::expand($template, $variables), $expansions);
+        self::assertContains(self::expandWithoutPhpWarnings($template, $variables), $expansions);
     }
 
     private static function parseSpecExamples(string $filename): \Generator
@@ -229,6 +229,19 @@ final class UriTemplateTest extends TestCase
                 yield [$case[0], (array) $case[1], $variables];
             }
         }
+    }
+
+    private static function expandWithoutPhpWarnings(string $template, array $variables): string
+    {
+        $result = null;
+
+        self::withoutPhpWarnings(static function () use ($template, $variables, &$result): void {
+            $result = UriTemplate::expand($template, $variables);
+        });
+
+        self::assertIsString($result);
+
+        return $result;
     }
 
     private function assertInvalidTemplate(string $template, array $variables = []): void


### PR DESCRIPTION
Adds reusable test helpers for upcoming URI template strictness changes and routes existing RFC fixture loading through an assertion-backed JSON loader.