### PR TITLE
Validate operators and variable lists

### DIFF
--- a/src/UriTemplate.php
+++ b/src/UriTemplate.php
@@ -11,6 +11,9 @@ namespace GuzzleHttp\UriTemplate;
  */
 final class UriTemplate
 {
+    private const RESERVED_OPERATORS = '=,!@|';
+    private const SUPPORTED_OPERATORS = '+#./;?&';
+
     /**
      * @var array<string, array{prefix:string, joiner:string, query:bool}> Hash for quick operator lookups
      */
@@ -233,35 +236,69 @@ final class UriTemplate
      */
     private static function parseExpression(string $expression): array
     {
-        $result = [];
+        $original = $expression;
+        $operator = '';
+        $first = $expression[0];
 
-        if (isset(self::$operatorHash[$expression[0]])) {
-            $result['operator'] = $expression[0];
+        if (isset(self::$operatorHash[$first])) {
+            $operator = $first;
             /** @var string */
             $expression = \substr($expression, 1);
-        } else {
-            $result['operator'] = '';
+        } elseif (\strpos(self::RESERVED_OPERATORS, $first) !== false) {
+            throw self::invalidExpression($original, \sprintf('unsupported operator "%s"', $first));
         }
 
-        $result['values'] = [];
-        foreach (\explode(',', $expression) as $value) {
-            $value = \trim($value);
-            $varspec = [];
-            if ($colonPos = \strpos($value, ':')) {
-                $varspec['value'] = (string) \substr($value, 0, $colonPos);
-                $varspec['modifier'] = ':';
-                $varspec['position'] = (int) \substr($value, $colonPos + 1);
-            } elseif (\substr($value, -1) === '*') {
-                $varspec['modifier'] = '*';
-                $varspec['value'] = (string) \substr($value, 0, -1);
-            } else {
-                $varspec['value'] = $value;
-                $varspec['modifier'] = '';
+        if ($expression === '') {
+            throw self::invalidExpression($original, 'missing variable list');
+        }
+
+        $values = [];
+        foreach (\explode(',', $expression) as $varspec) {
+            if ($varspec === '') {
+                throw self::invalidExpression($original, 'empty variable specifier');
             }
-            $result['values'][] = $varspec;
+
+            $values[] = self::parseVarSpecLenientForNow($original, $varspec);
         }
 
-        return $result;
+        return ['operator' => $operator, 'values' => $values];
+    }
+
+    /**
+     * @return array{value:string, modifier:(''|'*'|':'), position?:int}
+     */
+    private static function parseVarSpecLenientForNow(string $expression, string $varspec): array
+    {
+        if ($varspec !== \trim($varspec)) {
+            throw self::invalidExpression($expression, \sprintf('invalid whitespace in variable specifier "%s"', $varspec));
+        }
+
+        if (\strpos(self::SUPPORTED_OPERATORS.self::RESERVED_OPERATORS, $varspec[0]) !== false) {
+            throw self::invalidExpression($expression, \sprintf('invalid variable specifier "%s"', $varspec));
+        }
+
+        if ($colonPos = \strpos($varspec, ':')) {
+            return [
+                'value' => (string) \substr($varspec, 0, $colonPos),
+                'modifier' => ':',
+                'position' => (int) \substr($varspec, $colonPos + 1),
+            ];
+        }
+
+        if (\substr($varspec, -1) === '*') {
+            return ['modifier' => '*', 'value' => (string) \substr($varspec, 0, -1)];
+        }
+
+        return ['value' => $varspec, 'modifier' => ''];
+    }
+
+    private static function invalidExpression(string $expression, string $message): \InvalidArgumentException
+    {
+        return new \InvalidArgumentException(\sprintf(
+            'Invalid URI template expression "{%s}": %s.',
+            $expression,
+            $message
+        ));
     }
 
     /**

--- a/src/UriTemplate.php
+++ b/src/UriTemplate.php
@@ -236,6 +236,10 @@ final class UriTemplate
      */
     private static function parseExpression(string $expression): array
     {
+        if ($expression === '') {
+            throw self::invalidExpression($expression, 'empty expression');
+        }
+
         $original = $expression;
         $operator = '';
         $first = $expression[0];

--- a/tests/UriTemplateTest.php
+++ b/tests/UriTemplateTest.php
@@ -172,6 +172,7 @@ final class UriTemplateTest extends TestCase
             'unsupported bang operator' => ['{!hello}'],
             'unsupported at operator' => ['{@hello}'],
             'unsupported pipe operator' => ['{|var*}'],
+            'operator-like path varspec' => ['{/?id}'],
             'double query operator' => ['{??hello}'],
             'operator without varlist' => ['{?}'],
             'empty varspec before comma' => ['{,var}'],

--- a/tests/UriTemplateTest.php
+++ b/tests/UriTemplateTest.php
@@ -165,6 +165,30 @@ final class UriTemplateTest extends TestCase
         $this->assertInvalidTemplate($template, ['var' => 'value', 'id' => 'thing']);
     }
 
+    public static function invalidOperatorOrVarlistProvider(): array
+    {
+        return [
+            'unsupported equals operator' => ['{=path}'],
+            'unsupported bang operator' => ['{!hello}'],
+            'unsupported at operator' => ['{@hello}'],
+            'unsupported pipe operator' => ['{|var*}'],
+            'double query operator' => ['{??hello}'],
+            'operator without varlist' => ['{?}'],
+            'empty varspec before comma' => ['{,var}'],
+            'empty varspec after comma' => ['{var,}'],
+            'empty varspec between commas' => ['{var,,hello}'],
+            'whitespace after comma' => ['/resolution{?x, y}'],
+        ];
+    }
+
+    /**
+     * @dataProvider invalidOperatorOrVarlistProvider
+     */
+    public function testRejectsInvalidOperatorsAndVarlists(string $template): void
+    {
+        $this->assertInvalidTemplate($template, ['hello' => 'Hello World!', 'path' => '/foo/bar', 'var' => 'value', 'x' => '1024', 'y' => '768']);
+    }
+
     public static function expressionProvider(): array
     {
         return [


### PR DESCRIPTION
Rejects unsupported URI template operators, repeated operator characters, missing variable lists, empty variable specifiers, and whitespace-trimmed variable specifiers.