### PR TITLE
Validate URI template variable names

### DIFF
--- a/src/UriTemplate.php
+++ b/src/UriTemplate.php
@@ -13,6 +13,7 @@ final class UriTemplate
 {
     private const RESERVED_OPERATORS = '=,!@|';
     private const SUPPORTED_OPERATORS = '+#./;?&';
+    private const VARNAME_PATTERN = '(?:[A-Za-z0-9_]|%[0-9A-Fa-f]{2})(?:\.?(?:[A-Za-z0-9_]|%[0-9A-Fa-f]{2}))*';
 
     /**
      * @var array<string, array{prefix:string, joiner:string, query:bool}> Hash for quick operator lookups
@@ -281,19 +282,35 @@ final class UriTemplate
             throw self::invalidExpression($expression, \sprintf('invalid variable specifier "%s"', $varspec));
         }
 
-        if ($colonPos = \strpos($varspec, ':')) {
+        $colonPos = \strpos($varspec, ':');
+        if ($colonPos !== false) {
+            $name = (string) \substr($varspec, 0, $colonPos);
+            self::assertValidVariableName($expression, $name, $varspec);
+
             return [
-                'value' => (string) \substr($varspec, 0, $colonPos),
+                'value' => $name,
                 'modifier' => ':',
                 'position' => (int) \substr($varspec, $colonPos + 1),
             ];
         }
 
         if (\substr($varspec, -1) === '*') {
-            return ['modifier' => '*', 'value' => (string) \substr($varspec, 0, -1)];
+            $name = (string) \substr($varspec, 0, -1);
+            self::assertValidVariableName($expression, $name, $varspec);
+
+            return ['modifier' => '*', 'value' => $name];
         }
 
+        self::assertValidVariableName($expression, $varspec, $varspec);
+
         return ['value' => $varspec, 'modifier' => ''];
+    }
+
+    private static function assertValidVariableName(string $expression, string $name, string $varspec): void
+    {
+        if (\preg_match('/\A'.self::VARNAME_PATTERN.'\z/', $name) !== 1) {
+            throw self::invalidExpression($expression, \sprintf('invalid variable specifier "%s"', $varspec));
+        }
     }
 
     private static function invalidExpression(string $expression, string $message): \InvalidArgumentException

--- a/tests/UriTemplateTest.php
+++ b/tests/UriTemplateTest.php
@@ -225,6 +225,7 @@ final class UriTemplateTest extends TestCase
             'raw percent' => ['{bad%name}'],
             'short percent triplet' => ['{bad%2}'],
             'non-hex percent triplet' => ['{bad%ZZ}'],
+            'leading dot' => ['{?.var}'],
             'trailing dot' => ['{var.}'],
             'double dot' => ['{var..name}'],
             'raw unicode' => ["{Stra\xC3\x9Fe}"],

--- a/tests/UriTemplateTest.php
+++ b/tests/UriTemplateTest.php
@@ -190,6 +190,62 @@ final class UriTemplateTest extends TestCase
         $this->assertInvalidTemplate($template, ['hello' => 'Hello World!', 'path' => '/foo/bar', 'var' => 'value', 'x' => '1024', 'y' => '768']);
     }
 
+    public static function validVariableNameProvider(): array
+    {
+        return [
+            'letters' => ['{var}', ['var' => 'value'], 'value'],
+            'digits' => ['{42}', ['42' => 'answer'], 'answer'],
+            'underscore' => ['{first_name}', ['first_name' => 'John'], 'John'],
+            'dot separator' => ['{last.name}', ['last.name' => 'Doe'], 'Doe'],
+            'pct encoded space in name' => ['{/Some%20Thing}', ['Some%20Thing' => 'foo'], '/foo'],
+            'pct encoded unicode in name' => ['{?Stra%C3%9Fe}', ['Stra%C3%9Fe' => 'Gruner Weg'], '?Stra%C3%9Fe=Gruner%20Weg'],
+        ];
+    }
+
+    /**
+     * @dataProvider validVariableNameProvider
+     */
+    public function testExpandsValidVariableNames(string $template, array $variables, string $expansion): void
+    {
+        self::assertSame($expansion, UriTemplate::expand($template, $variables));
+    }
+
+    public static function invalidVariableNameProvider(): array
+    {
+        return [
+            'space' => ['{with space}'],
+            'leading space' => ['{ leading_space}'],
+            'trailing space' => ['{trailing_space }'],
+            'hyphen' => ['/{default-graph-uri}'],
+            'tilde' => ['/people/{~thing}'],
+            'dollar' => ['{$var}'],
+            'query delimiter in name' => ['/search{?x=1&admin}'],
+            'matrix delimiter in name' => ['/users{;role;admin}'],
+            'slash in name' => ['{a/b}'],
+            'raw percent' => ['{bad%name}'],
+            'short percent triplet' => ['{bad%2}'],
+            'non-hex percent triplet' => ['{bad%ZZ}'],
+            'trailing dot' => ['{var.}'],
+            'double dot' => ['{var..name}'],
+            'raw unicode' => ["{Stra\xC3\x9Fe}"],
+            'default syntax' => ['{?empty=default,var}'],
+            'join extension syntax' => ['?{-join|&|var,list}'],
+            'pipe extension syntax' => ['x{?empty|foo=none}'],
+            'extension after expression' => ['{var}{-prefix|/-/|var}'],
+            'operator-like suffix' => ['/h{#hello+}'],
+            'operator-like suffix after fragment literal' => ['/h#{hello+}'],
+            'star-prefixed name' => ['{*keys?}'],
+        ];
+    }
+
+    /**
+     * @dataProvider invalidVariableNameProvider
+     */
+    public function testRejectsInvalidVariableNames(string $template): void
+    {
+        $this->assertInvalidTemplate($template);
+    }
+
     public static function expressionProvider(): array
     {
         return [


### PR DESCRIPTION
Rejects URI template variable names that do not match RFC6570 grammar, including delimiter characters, malformed percent triplets, extension syntax, and raw non-ASCII names.