### PR TITLE
Reject prefix modifiers on composite values

### DIFF
--- a/src/UriTemplate.php
+++ b/src/UriTemplate.php
@@ -32,7 +32,7 @@ final class UriTemplate
     /**
      * @param array<string,mixed> $variables Variables to use in the template expansion
      *
-     * @throws \InvalidArgumentException When the template syntax is invalid
+     * @throws \InvalidArgumentException When the template syntax or referenced variable shape is invalid
      * @throws \RuntimeException
      */
     public static function expand(string $template, array $variables): string
@@ -131,11 +131,20 @@ final class UriTemplate
         $allUndefined = true;
 
         foreach ($parsed['values'] as $value) {
-            if (!isset($variables[$value['value']])) {
+            if (self::isUndefinedVariable($variables, $value['value'])) {
                 continue;
             }
 
             $variable = $variables[$value['value']];
+
+            if ($value['modifier'] === ':' && \is_array($variable)) {
+                throw self::invalidVariable(
+                    $matches[1],
+                    $value['value'],
+                    'prefix modifier is not applicable to composite values'
+                );
+            }
+
             $actuallyUseQuery = $useQuery;
             $expanded = '';
 
@@ -308,6 +317,24 @@ final class UriTemplate
     {
         return new \InvalidArgumentException(\sprintf(
             'Invalid URI template expression "{%s}": %s.',
+            $expression,
+            $message
+        ));
+    }
+
+    /**
+     * @param array<string,mixed> $variables
+     */
+    private static function isUndefinedVariable(array $variables, string $name): bool
+    {
+        return !\array_key_exists($name, $variables) || $variables[$name] === null;
+    }
+
+    private static function invalidVariable(string $expression, string $path, string $message): \InvalidArgumentException
+    {
+        return new \InvalidArgumentException(\sprintf(
+            'Invalid URI template variable "%s" in "{%s}": %s.',
+            $path,
             $expression,
             $message
         ));

--- a/src/UriTemplate.php
+++ b/src/UriTemplate.php
@@ -137,6 +137,10 @@ final class UriTemplate
 
             $variable = $variables[$value['value']];
 
+            if (\is_array($variable) && $variable === []) {
+                continue;
+            }
+
             if ($value['modifier'] === ':' && \is_array($variable)) {
                 throw self::invalidVariable(
                     $matches[1],

--- a/tests/UriTemplateTest.php
+++ b/tests/UriTemplateTest.php
@@ -291,6 +291,31 @@ final class UriTemplateTest extends TestCase
         $this->assertInvalidTemplate($template);
     }
 
+    public static function prefixOnCompositeProvider(): array
+    {
+        return [
+            'list simple' => ['{list:1}', ['list' => ['red', 'green']]],
+            'map simple' => ['{keys:1}', ['keys' => ['semi' => ';']]],
+            'reserved map' => ['{+keys:1}', ['keys' => ['semi' => ';']]],
+            'matrix map' => ['{;keys:1}', ['keys' => ['semi' => ';']]],
+            'empty list' => ['{list:1}', ['list' => []]],
+        ];
+    }
+
+    /**
+     * @dataProvider prefixOnCompositeProvider
+     */
+    public function testRejectsPrefixModifiersOnCompositeValues(string $template, array $variables): void
+    {
+        $this->assertInvalidTemplate($template, $variables);
+    }
+
+    public function testIgnoresPrefixModifiersOnUndefinedVariables(): void
+    {
+        self::assertSame('', UriTemplate::expand('{missing:1}', []));
+        self::assertSame('', UriTemplate::expand('{missing:1}', ['missing' => null]));
+    }
+
     public static function expressionProvider(): array
     {
         return [

--- a/tests/UriTemplateTest.php
+++ b/tests/UriTemplateTest.php
@@ -298,7 +298,6 @@ final class UriTemplateTest extends TestCase
             'map simple' => ['{keys:1}', ['keys' => ['semi' => ';']]],
             'reserved map' => ['{+keys:1}', ['keys' => ['semi' => ';']]],
             'matrix map' => ['{;keys:1}', ['keys' => ['semi' => ';']]],
-            'empty list' => ['{list:1}', ['list' => []]],
         ];
     }
 
@@ -314,6 +313,7 @@ final class UriTemplateTest extends TestCase
     {
         self::assertSame('', UriTemplate::expand('{missing:1}', []));
         self::assertSame('', UriTemplate::expand('{missing:1}', ['missing' => null]));
+        self::assertSame('', UriTemplate::expand('{list:1}', ['list' => []]));
     }
 
     public static function expressionProvider(): array


### PR DESCRIPTION
Rejects prefix modifiers when the referenced variable is a list or associative array, while preserving missing and null variables as undefined.