### PR TITLE
Validate referenced variable shapes

### DIFF
--- a/src/UriTemplate.php
+++ b/src/UriTemplate.php
@@ -14,6 +14,7 @@ final class UriTemplate
     private const RESERVED_OPERATORS = '=,!@|';
     private const SUPPORTED_OPERATORS = '+#./;?&';
     private const VARNAME_PATTERN = '(?:[A-Za-z0-9_]|%[0-9A-Fa-f]{2})(?:\.?(?:[A-Za-z0-9_]|%[0-9A-Fa-f]{2}))*';
+    private const MAX_VARIABLE_DEPTH = 64;
 
     /**
      * @var array<string, array{prefix:string, joiner:string, query:bool}> Hash for quick operator lookups
@@ -141,13 +142,7 @@ final class UriTemplate
                 continue;
             }
 
-            if ($value['modifier'] === ':' && \is_array($variable)) {
-                throw self::invalidVariable(
-                    $matches[1],
-                    $value['value'],
-                    'prefix modifier is not applicable to composite values'
-                );
-            }
+            self::assertVariableShape($value, $variable, $matches[1], $parsed['operator']);
 
             $actuallyUseQuery = $useQuery;
             $expanded = '';
@@ -342,6 +337,167 @@ final class UriTemplate
             $expression,
             $message
         ));
+    }
+
+    /**
+     * @param array{value:string, modifier:(''|'*'|':'), position?:int} $varspec
+     * @param mixed                                                     $variable
+     */
+    private static function assertVariableShape(array $varspec, $variable, string $expression, string $operator): void
+    {
+        if (self::isScalarLike($variable)) {
+            return;
+        }
+
+        if (!\is_array($variable)) {
+            throw self::invalidVariable(
+                $expression,
+                $varspec['value'],
+                \sprintf(
+                    'expected scalar, stringable object, list, or associative array; got %s',
+                    self::describeType($variable)
+                )
+            );
+        }
+
+        if ($varspec['modifier'] === ':') {
+            throw self::invalidVariable(
+                $expression,
+                $varspec['value'],
+                'prefix modifier is not applicable to composite values'
+            );
+        }
+
+        $isAssoc = self::isAssoc($variable);
+
+        if (!$isAssoc) {
+            self::assertListShape($varspec['value'], $variable, $expression);
+
+            return;
+        }
+
+        $allowNestedArrays = $varspec['modifier'] === '*' && ($operator === '?' || $operator === '&');
+
+        self::assertMapShape($varspec['value'], $variable, $expression, $allowNestedArrays, 0);
+    }
+
+    /**
+     * @param mixed $value
+     */
+    private static function isScalarLike($value): bool
+    {
+        return \is_scalar($value) || (\is_object($value) && \method_exists($value, '__toString'));
+    }
+
+    /**
+     * @param mixed $value
+     */
+    private static function describeType($value): string
+    {
+        if (\is_object($value)) {
+            return 'object('.\get_class($value).')';
+        }
+
+        if (\is_resource($value)) {
+            return 'resource('.\get_resource_type($value).')';
+        }
+
+        return \gettype($value);
+    }
+
+    /**
+     * @param array<array-key,mixed> $value
+     */
+    private static function assertListShape(string $path, array $value, string $expression): void
+    {
+        foreach ($value as $index => $member) {
+            $memberPath = \sprintf('%s[%d]', $path, $index);
+
+            if ($member === null) {
+                throw self::invalidVariable($expression, $memberPath, 'nested null values are not supported');
+            }
+
+            if (self::isScalarLike($member)) {
+                continue;
+            }
+
+            throw self::invalidVariable(
+                $expression,
+                $memberPath,
+                \sprintf('expected scalar or stringable object; got %s', self::describeType($member))
+            );
+        }
+    }
+
+    /**
+     * @param array<array-key,mixed> $value
+     */
+    private static function assertMapShape(
+        string $path,
+        array $value,
+        string $expression,
+        bool $allowNestedArrays,
+        int $depth
+    ): void {
+        if ($depth > self::MAX_VARIABLE_DEPTH) {
+            throw self::invalidVariable($expression, $path, 'maximum variable nesting depth exceeded');
+        }
+
+        foreach ($value as $key => $member) {
+            $memberPath = \sprintf('%s[%s]', $path, (string) $key);
+
+            if ($member === null) {
+                throw self::invalidVariable($expression, $memberPath, 'nested null values are not supported');
+            }
+
+            if (self::isScalarLike($member)) {
+                continue;
+            }
+
+            if (\is_array($member) && $allowNestedArrays) {
+                self::assertNestedQueryShape($memberPath, $member, $expression, $depth + 1);
+                continue;
+            }
+
+            throw self::invalidVariable(
+                $expression,
+                $memberPath,
+                \sprintf('expected scalar%s; got %s', $allowNestedArrays ? ', stringable object, or nested array' : ' or stringable object', self::describeType($member))
+            );
+        }
+    }
+
+    /**
+     * @param array<array-key,mixed> $value
+     */
+    private static function assertNestedQueryShape(string $path, array $value, string $expression, int $depth): void
+    {
+        if ($depth > self::MAX_VARIABLE_DEPTH) {
+            throw self::invalidVariable($expression, $path, 'maximum variable nesting depth exceeded');
+        }
+
+        foreach ($value as $key => $member) {
+            $memberPath = \sprintf('%s[%s]', $path, (string) $key);
+
+            if ($member === null) {
+                throw self::invalidVariable($expression, $memberPath, 'nested null values are not supported');
+            }
+
+            if (\is_scalar($member)) {
+                continue;
+            }
+
+            if (\is_array($member)) {
+                self::assertNestedQueryShape($memberPath, $member, $expression, $depth + 1);
+                continue;
+            }
+
+            throw self::invalidVariable(
+                $expression,
+                $memberPath,
+                \sprintf('expected scalar or nested array; got %s', self::describeType($member))
+            );
+        }
     }
 
     /**

--- a/tests/UriTemplateTest.php
+++ b/tests/UriTemplateTest.php
@@ -316,6 +316,70 @@ final class UriTemplateTest extends TestCase
         self::assertSame('', UriTemplate::expand('{list:1}', ['list' => []]));
     }
 
+    public static function supportedVariableShapeProvider(): array
+    {
+        return [
+            'string' => ['{x}', ['x' => 'value'], 'value'],
+            'int zero' => ['{x}', ['x' => 0], '0'],
+            'float' => ['{x}', ['x' => 37.76], '37.76'],
+            'false' => ['{x}', ['x' => false], ''],
+            'true' => ['{x}', ['x' => true], '1'],
+            'empty string query' => ['{?x}', ['x' => ''], '?x='],
+            'top-level null skipped' => ['{?x,y}', ['x' => null, 'y' => 'yes'], '?y=yes'],
+            'stringable object' => ['{x}', ['x' => new StringableValue('ok')], 'ok'],
+            'list' => ['{/x*}', ['x' => ['red', 'green']], '/red/green'],
+            'map' => ['{?x*}', ['x' => ['a' => 'b']], '?a=b'],
+            'nested exploded map extension' => ['{?x*}', ['x' => ['a' => ['b' => 'c']]], '?a%5Bb%5D=c'],
+        ];
+    }
+
+    /**
+     * @dataProvider supportedVariableShapeProvider
+     */
+    public function testExpandsSupportedVariableShapes(string $template, array $variables, string $expansion): void
+    {
+        self::assertSame($expansion, UriTemplate::expand($template, $variables));
+    }
+
+    public static function invalidVariableShapeProvider(): array
+    {
+        $resource = \fopen('php://temp', 'r');
+        self::assertIsResource($resource);
+
+        return [
+            'stdClass scalar' => ['{x}', ['x' => new \stdClass()]],
+            'closure scalar' => ['{x}', ['x' => static function (): void {}]],
+            'resource scalar' => ['{x}', ['x' => $resource]],
+            'nested list in list' => ['{?x}', ['x' => [['a']]]],
+            'nested array in unexploded map' => ['{?x}', ['x' => ['a' => ['b' => 'c']]]],
+            'nested array in non-query exploded map' => ['{/x*}', ['x' => ['a' => ['b' => 'c']]]],
+            'nested null in list' => ['{?x*}', ['x' => ['a', null]]],
+            'nested null in map' => ['{?x*}', ['x' => ['a' => null]]],
+            'nested object in query extension' => ['{?x*}', ['x' => ['a' => ['b' => new \stdClass()]]]],
+        ];
+    }
+
+    /**
+     * @dataProvider invalidVariableShapeProvider
+     */
+    public function testRejectsInvalidVariableShapes(string $template, array $variables): void
+    {
+        $this->assertInvalidTemplate($template, $variables);
+    }
+
+    public function testIgnoresUnusedInvalidVariableShapes(): void
+    {
+        self::assertSame('ok', UriTemplate::expand('{x}', ['x' => 'ok', 'unused' => new \stdClass()]));
+    }
+
+    public function testRejectsRecursiveArrayVariables(): void
+    {
+        $recursive = [];
+        $recursive['self'] = &$recursive;
+
+        $this->assertInvalidTemplate('{?recursive*}', ['recursive' => $recursive]);
+    }
+
     public static function expressionProvider(): array
     {
         return [
@@ -453,5 +517,21 @@ final class UriTemplateTest extends TestCase
         self::assertIsArray($decoded);
 
         return $decoded;
+    }
+}
+
+final class StringableValue
+{
+    /** @var string */
+    private $value;
+
+    public function __construct(string $value)
+    {
+        $this->value = $value;
+    }
+
+    public function __toString(): string
+    {
+        return $this->value;
     }
 }

--- a/tests/UriTemplateTest.php
+++ b/tests/UriTemplateTest.php
@@ -327,6 +327,8 @@ final class UriTemplateTest extends TestCase
             'empty string query' => ['{?x}', ['x' => ''], '?x='],
             'top-level null skipped' => ['{?x,y}', ['x' => null, 'y' => 'yes'], '?y=yes'],
             'stringable object' => ['{x}', ['x' => new StringableValue('ok')], 'ok'],
+            'stringable object in list' => ['{x}', ['x' => [new StringableValue('ok')]], 'ok'],
+            'stringable object in map' => ['{?x*}', ['x' => ['a' => new StringableValue('ok')]], '?a=ok'],
             'list' => ['{/x*}', ['x' => ['red', 'green']], '/red/green'],
             'map' => ['{?x*}', ['x' => ['a' => 'b']], '?a=b'],
             'nested exploded map extension' => ['{?x*}', ['x' => ['a' => ['b' => 'c']]], '?a%5Bb%5D=c'],
@@ -350,6 +352,8 @@ final class UriTemplateTest extends TestCase
             'stdClass scalar' => ['{x}', ['x' => new \stdClass()]],
             'closure scalar' => ['{x}', ['x' => static function (): void {}]],
             'resource scalar' => ['{x}', ['x' => $resource]],
+            'object in list' => ['{?x}', ['x' => [new \stdClass()]]],
+            'object in map' => ['{?x}', ['x' => ['a' => new \stdClass()]]],
             'nested list in list' => ['{?x}', ['x' => [['a']]]],
             'nested array in unexploded map' => ['{?x}', ['x' => ['a' => ['b' => 'c']]]],
             'nested array in non-query exploded map' => ['{/x*}', ['x' => ['a' => ['b' => 'c']]]],
@@ -378,6 +382,17 @@ final class UriTemplateTest extends TestCase
         $recursive['self'] = &$recursive;
 
         $this->assertInvalidTemplate('{?recursive*}', ['recursive' => $recursive]);
+    }
+
+    public function testRejectsTooDeepArrayVariables(): void
+    {
+        $tooDeep = 'leaf';
+
+        for ($i = 0; $i < 66; ++$i) {
+            $tooDeep = ['x' => $tooDeep];
+        }
+
+        $this->assertInvalidTemplate('{?x*}', ['x' => ['a' => $tooDeep]]);
     }
 
     public static function expressionProvider(): array


### PR DESCRIPTION
Rejects unsupported referenced variable values before expansion, while preserving supported scalars, stringable objects, lists, maps, and the existing nested exploded query extension.