### PR TITLE
Use deterministic array shape detection

### DIFF
--- a/src/UriTemplate.php
+++ b/src/UriTemplate.php
@@ -502,15 +502,14 @@ final class UriTemplate
 
     /**
      * Determines if an array is associative.
-     *
-     * This makes the assumption that input arrays are sequences or hashes.
-     * This assumption is a tradeoff for accuracy in favor of speed, but it
-     * should work in almost every case where input is supplied for a URI
-     * template.
      */
     private static function isAssoc(array $array): bool
     {
-        return $array && \array_keys($array)[0] !== 0;
+        if ($array === []) {
+            return false;
+        }
+
+        return \array_keys($array) !== \range(0, \count($array) - 1);
     }
 
     private static function encodeValue(string $value, bool $allowReserved): string

--- a/src/UriTemplate.php
+++ b/src/UriTemplate.php
@@ -501,7 +501,7 @@ final class UriTemplate
     }
 
     /**
-     * Determines if an array is associative.
+     * Determines if an array should be expanded as a map.
      */
     private static function isAssoc(array $array): bool
     {

--- a/tests/UriTemplateTest.php
+++ b/tests/UriTemplateTest.php
@@ -399,6 +399,7 @@ final class UriTemplateTest extends TestCase
     {
         return [
             'dense list' => ['{?x*}', ['x' => ['a', 'b']], '?x=a&x=b'],
+            'zero-based sparse numeric map' => ['{?x*}', ['x' => [0 => 'a', 2 => 'b']], '?0=a&2=b'],
             'sparse numeric map' => ['{?x*}', ['x' => [1 => 'a', 3 => 'b']], '?1=a&3=b'],
             'mixed map' => ['{?x*}', ['x' => [0 => 'a', 'b' => 'c']], '?0=a&b=c'],
         ];

--- a/tests/UriTemplateTest.php
+++ b/tests/UriTemplateTest.php
@@ -395,6 +395,23 @@ final class UriTemplateTest extends TestCase
         $this->assertInvalidTemplate('{?x*}', ['x' => ['a' => $tooDeep]]);
     }
 
+    public static function deterministicArrayShapeProvider(): array
+    {
+        return [
+            'dense list' => ['{?x*}', ['x' => ['a', 'b']], '?x=a&x=b'],
+            'sparse numeric map' => ['{?x*}', ['x' => [1 => 'a', 3 => 'b']], '?1=a&3=b'],
+            'mixed map' => ['{?x*}', ['x' => [0 => 'a', 'b' => 'c']], '?0=a&b=c'],
+        ];
+    }
+
+    /**
+     * @dataProvider deterministicArrayShapeProvider
+     */
+    public function testExpandsDeterministicArrayShapes(string $template, array $variables, string $expansion): void
+    {
+        self::assertSame($expansion, UriTemplate::expand($template, $variables));
+    }
+
     public static function expressionProvider(): array
     {
         return [


### PR DESCRIPTION
Classifies dense zero-indexed arrays as lists and treats sparse or mixed-key arrays as maps, avoiding first-key-dependent expansion behavior.