### PR TITLE
Count prefixes by Unicode characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 ### Fixed
 - Fixed reserved and fragment expansion preserving existing pct-encoded triplets in variable values
 - Fixed invalid template expressions being accepted as parameter names in query and path-style parameter expansions
-- Fixed prefix modifiers counting bytes instead of Unicode characters and pct-encoded triplets
+- Fixed prefix modifiers counting bytes instead of Unicode code points and pct-encoded triplets
 - Fixed unsupported variable shapes producing PHP warnings, conversion errors, or lossy `Array` output
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 ### Fixed
 - Fixed reserved and fragment expansion preserving existing pct-encoded triplets in variable values
 - Fixed invalid template expressions being accepted as parameter names in query and path-style parameter expansions
+- Fixed prefix modifiers counting bytes instead of Unicode characters and pct-encoded triplets
 - Fixed unsupported variable shapes producing PHP warnings, conversion errors, or lossy `Array` output
 
 ### Removed

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -79,7 +79,9 @@ nested null values, recursive arrays, and arrays nested too deeply.
 
 Prefix modifiers, such as `{var:3}`, are only valid for scalar or stringable
 values. Applying a prefix modifier to a list or map now throws
-`InvalidArgumentException`.
+`InvalidArgumentException`. Prefix lengths are counted as Unicode characters and
+existing pct-encoded triplets, not bytes. A prefixed string value must be valid
+UTF-8, otherwise expansion throws `InvalidArgumentException`.
 
 #### Reserved Expansion
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -79,9 +79,10 @@ nested null values, recursive arrays, and arrays nested too deeply.
 
 Prefix modifiers, such as `{var:3}`, are only valid for scalar or stringable
 values. Applying a prefix modifier to a list or map now throws
-`InvalidArgumentException`. Prefix lengths are counted as Unicode characters and
-existing pct-encoded triplets, not bytes. A prefixed string value must be valid
-UTF-8, otherwise expansion throws `InvalidArgumentException`.
+`InvalidArgumentException`. Prefix lengths are counted as Unicode code points
+and existing pct-encoded triplets, not bytes or visual grapheme clusters. A
+prefixed string value must be valid UTF-8, otherwise expansion throws
+`InvalidArgumentException`.
 
 #### Reserved Expansion
 

--- a/src/UriTemplate.php
+++ b/src/UriTemplate.php
@@ -203,9 +203,11 @@ final class UriTemplate
                 }
             } else {
                 $allUndefined = false;
+
                 if ($value['modifier'] === ':' && isset($value['position'])) {
-                    $variable = \substr((string) $variable, 0, $value['position']);
+                    $variable = self::prefixValue((string) $variable, $value['position'], $matches[1], $value['value']);
                 }
+
                 $expanded = self::encodeValue((string) $variable, $allowReserved);
             }
 
@@ -510,6 +512,22 @@ final class UriTemplate
         }
 
         return \array_keys($array) !== \range(0, \count($array) - 1);
+    }
+
+    private static function prefixValue(string $value, int $length, string $expression, string $name): string
+    {
+        if ($value === '') {
+            return '';
+        }
+
+        $matches = [];
+        $result = \preg_match_all('/%[0-9A-Fa-f]{2}|./us', $value, $matches);
+
+        if ($result === false || \preg_last_error() !== \PREG_NO_ERROR) {
+            throw self::invalidVariable($expression, $name, 'prefix modifier requires valid UTF-8');
+        }
+
+        return \implode('', \array_slice($matches[0], 0, $length));
     }
 
     private static function encodeValue(string $value, bool $allowReserved): string

--- a/tests/UriTemplateTest.php
+++ b/tests/UriTemplateTest.php
@@ -273,6 +273,7 @@ final class UriTemplateTest extends TestCase
             'reserved unicode and slash characters' => ['{+var:2}', ['var' => "\xC3\xA9/clair"], '%C3%A9/'],
             'query unicode character' => ['{?var:1}', ['var' => "\xC3\xA9clair"], '?var=%C3%A9'],
             'pct triplet counts as one character' => ['{var:1}', ['var' => '%2Fabc'], '%252F'],
+            'reserved pct triplet counts as one character' => ['{+var:1}', ['var' => '%2Fabc'], '%2F'],
         ];
     }
 

--- a/tests/UriTemplateTest.php
+++ b/tests/UriTemplateTest.php
@@ -265,6 +265,30 @@ final class UriTemplateTest extends TestCase
         self::assertSame($expansion, UriTemplate::expand($template, $variables));
     }
 
+    public static function unicodePrefixProvider(): array
+    {
+        return [
+            'simple first unicode character' => ['{var:1}', ['var' => "\xC3\xA9clair"], '%C3%A9'],
+            'simple unicode and ascii characters' => ['{var:2}', ['var' => "\xC3\xA9clair"], '%C3%A9c'],
+            'reserved unicode and slash characters' => ['{+var:2}', ['var' => "\xC3\xA9/clair"], '%C3%A9/'],
+            'query unicode character' => ['{?var:1}', ['var' => "\xC3\xA9clair"], '?var=%C3%A9'],
+            'pct triplet counts as one character' => ['{var:1}', ['var' => '%2Fabc'], '%252F'],
+        ];
+    }
+
+    /**
+     * @dataProvider unicodePrefixProvider
+     */
+    public function testExpandsUnicodePrefixes(string $template, array $variables, string $expansion): void
+    {
+        self::assertSame($expansion, UriTemplate::expand($template, $variables));
+    }
+
+    public function testRejectsInvalidUtf8PrefixValues(): void
+    {
+        $this->assertInvalidTemplate('{var:1}', ['var' => "\xC3"]);
+    }
+
     public static function invalidModifierProvider(): array
     {
         return [


### PR DESCRIPTION
Counts prefix modifiers by Unicode code points and pct-encoded triplets instead of bytes, and rejects invalid UTF-8 for prefixed values.