### PR TITLE
Validate and encode URI template literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 
 ### Changed
 - Invalid URI template syntax now throws `InvalidArgumentException` instead of being partially expanded or returned unchanged
+- Literal template text is now validated according to RFC 6570, and valid non-ASCII literals are pct-encoded during expansion
 - URI template variable names and modifiers are now validated according to RFC 6570
 - Prefix modifiers are now rejected for list and map values
 - Referenced variable values are now validated before expansion

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 
 ### Changed
 - Invalid URI template syntax now throws `InvalidArgumentException` instead of being partially expanded or returned unchanged
-- Literal template text is now validated according to RFC 6570, and valid non-ASCII literals are pct-encoded during expansion
+- Literal template text is now validated, and valid non-ASCII literals are pct-encoded during expansion
 - URI template variable names and modifiers are now validated according to RFC 6570
 - Prefix modifiers are now rejected for list and map values
 - Referenced variable values are now validated before expansion

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -25,12 +25,13 @@ specifiers, and prefix modifiers applied to list or map values.
 
 #### Literal Text
 
-Literal text outside expressions is now validated according to RFC 6570. Invalid
-literal characters, including spaces, raw or malformed `%` sequences, double
-quotes, controls, `<`, `>`, backslash, caret, backtick, and pipe, now throw
-`InvalidArgumentException`. Valid non-ASCII literal text must be valid UTF-8 and
-is pct-encoded during expansion. Templates without expressions are also
-validated and encoded.
+Literal text outside expressions is now validated and encoded using RFC 6570
+literal rules, with apostrophes preserved for compatibility with upstream RFC
+example fixtures. Invalid literal characters, including spaces, raw or malformed
+`%` sequences, double quotes, controls, `<`, `>`, backslash, caret, backtick,
+and pipe, now throw `InvalidArgumentException`. Valid non-ASCII literal text
+must be valid UTF-8 and is pct-encoded during expansion. Templates without
+expressions are also validated and encoded.
 
 Before:
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -23,6 +23,27 @@ Invalid template syntax includes malformed braces, unsupported operators,
 invalid variable names, invalid modifiers, repeated operator-like variable
 specifiers, and prefix modifiers applied to list or map values.
 
+#### Literal Text
+
+Literal text outside expressions is now validated according to RFC 6570. Invalid
+literal characters, including spaces, raw or malformed `%` sequences, double
+quotes, controls, `<`, `>`, backslash, caret, backtick, and pipe, now throw
+`InvalidArgumentException`. Valid non-ASCII literal text must be valid UTF-8 and
+is pct-encoded during expansion. Templates without expressions are also
+validated and encoded.
+
+Before:
+
+```php
+UriTemplate::expand('/search terms/{id}', ['id' => 1]);
+```
+
+After:
+
+```php
+UriTemplate::expand('/search%20terms/{id}', ['id' => 1]);
+```
+
 #### Variable Names
 
 Variable names in templates must use RFC 6570 syntax: ASCII letters, ASCII

--- a/src/UriTemplate.php
+++ b/src/UriTemplate.php
@@ -38,7 +38,7 @@ final class UriTemplate
      */
     public static function expand(string $template, array $variables): string
     {
-        self::validateTemplateStructure($template);
+        $template = self::prepareTemplate($template);
 
         if (false === \strpos($template, '{')) {
             return $template;
@@ -70,14 +70,21 @@ final class UriTemplate
         };
     }
 
-    private static function validateTemplateStructure(string $template): void
+    private static function prepareTemplate(string $template): string
     {
         $length = \strlen($template);
+        $prepared = '';
+        $literalStart = 0;
 
         for ($offset = 0; $offset < $length; ++$offset) {
             $char = $template[$offset];
 
             if ($char === '{') {
+                $prepared .= self::encodeLiteralSegment(
+                    \substr($template, $literalStart, $offset - $literalStart),
+                    $literalStart
+                );
+
                 $end = \strpos($template, '}', $offset + 1);
 
                 if ($end === false) {
@@ -94,7 +101,10 @@ final class UriTemplate
                     throw self::invalidTemplate($offset, 'nested expressions are not allowed');
                 }
 
+                $prepared .= \substr($template, $offset, $end - $offset + 1);
                 $offset = $end;
+                $literalStart = $end + 1;
+
                 continue;
             }
 
@@ -102,6 +112,8 @@ final class UriTemplate
                 throw self::invalidTemplate($offset, 'unmatched "}"');
             }
         }
+
+        return $prepared.self::encodeLiteralSegment(\substr($template, $literalStart), $literalStart);
     }
 
     private static function invalidTemplate(int $offset, string $message): \InvalidArgumentException
@@ -528,6 +540,86 @@ final class UriTemplate
         }
 
         return \implode('', \array_slice($matches[0], 0, $length));
+    }
+
+    private static function encodeLiteralSegment(string $literal, int $baseOffset): string
+    {
+        if ($literal === '') {
+            return '';
+        }
+
+        $matches = [];
+        $result = \preg_match_all('/%[0-9A-Fa-f]{2}|./us', $literal, $matches, \PREG_OFFSET_CAPTURE);
+
+        if ($result === false || \preg_last_error() !== \PREG_NO_ERROR) {
+            throw self::invalidTemplate($baseOffset, 'literal text must be valid UTF-8');
+        }
+
+        $encoded = '';
+        $position = 0;
+
+        foreach ($matches[0] as $match) {
+            $token = $match[0];
+            $offset = $match[1];
+
+            if ($offset < 0) {
+                throw self::invalidTemplate($baseOffset + $position, 'invalid literal character');
+            }
+
+            if ($offset !== $position) {
+                throw self::invalidTemplate($baseOffset + $position, 'invalid literal character');
+            }
+
+            $position = $offset + \strlen($token);
+
+            if (\preg_match('/\A%[0-9A-Fa-f]{2}\z/', $token) === 1) {
+                $encoded .= $token;
+                continue;
+            }
+
+            if (\strlen($token) === 1) {
+                if (self::isAllowedAsciiLiteral($token)) {
+                    $encoded .= $token;
+                    continue;
+                }
+
+                throw self::invalidTemplate($baseOffset + $offset, $token === '%' ? 'invalid percent-encoded triplet' : 'invalid literal character');
+            }
+
+            if (!self::isAllowedUnicodeLiteral($token)) {
+                throw self::invalidTemplate($baseOffset + $offset, 'invalid literal character');
+            }
+
+            $encoded .= \rawurlencode($token);
+        }
+
+        if ($position !== \strlen($literal)) {
+            throw self::invalidTemplate($baseOffset + $position, 'invalid literal character');
+        }
+
+        return $encoded;
+    }
+
+    private static function isAllowedAsciiLiteral(string $char): bool
+    {
+        $ord = \ord($char);
+
+        return $ord === 0x21
+            || ($ord >= 0x23 && $ord <= 0x24)
+            || $ord === 0x26
+            || $ord === 0x27
+            || ($ord >= 0x28 && $ord <= 0x3B)
+            || $ord === 0x3D
+            || ($ord >= 0x3F && $ord <= 0x5B)
+            || $ord === 0x5D
+            || $ord === 0x5F
+            || ($ord >= 0x61 && $ord <= 0x7A)
+            || $ord === 0x7E;
+    }
+
+    private static function isAllowedUnicodeLiteral(string $char): bool
+    {
+        return \preg_match('/\A(?:[\x{A0}-\x{D7FF}\x{E000}-\x{FDCF}\x{FDF0}-\x{FFEF}]|[\x{10000}-\x{1FFFD}\x{20000}-\x{2FFFD}\x{30000}-\x{3FFFD}\x{40000}-\x{4FFFD}\x{50000}-\x{5FFFD}\x{60000}-\x{6FFFD}\x{70000}-\x{7FFFD}\x{80000}-\x{8FFFD}\x{90000}-\x{9FFFD}\x{A0000}-\x{AFFFD}\x{B0000}-\x{BFFFD}\x{C0000}-\x{CFFFD}\x{D0000}-\x{DFFFD}\x{E1000}-\x{EFFFD}\x{F0000}-\x{FFFFD}\x{100000}-\x{10FFFD}])\z/u', $char) === 1;
     }
 
     private static function encodeValue(string $value, bool $allowReserved): string

--- a/src/UriTemplate.php
+++ b/src/UriTemplate.php
@@ -607,6 +607,7 @@ final class UriTemplate
         return $ord === 0x21
             || ($ord >= 0x23 && $ord <= 0x24)
             || $ord === 0x26
+            // Upstream RFC example fixtures include apostrophes as literal text.
             || $ord === 0x27
             || ($ord >= 0x28 && $ord <= 0x3B)
             || $ord === 0x3D

--- a/tests/UriTemplateTest.php
+++ b/tests/UriTemplateTest.php
@@ -126,6 +126,56 @@ final class UriTemplateTest extends TestCase
         self::assertSame($expansion, UriTemplate::expand($template, $variables));
     }
 
+    public static function literalProvider(): array
+    {
+        return [
+            'no expressions' => ['foo', [], 'foo'],
+            'expression with literal path' => ['/users/{id}', ['id' => '123'], '/users/123'],
+            'pct encoded literal' => ['/files/%2F/{id}', ['id' => 'a'], '/files/%2F/a'],
+            'unicode literal' => ["/caf\xC3\xA9/{id}", ['id' => 'a'], '/caf%C3%A9/a'],
+            'emoji literal' => ["/\xF0\x9F\x98\x80/{id}", ['id' => 'a'], '/%F0%9F%98%80/a'],
+        ];
+    }
+
+    /**
+     * @dataProvider literalProvider
+     */
+    public function testExpandsLiteralText(string $template, array $variables, string $expansion): void
+    {
+        self::assertSame($expansion, UriTemplate::expand($template, $variables));
+    }
+
+    public static function invalidLiteralProvider(): array
+    {
+        return [
+            'space' => ['foo bar'],
+            'trailing percent' => ['foo%'],
+            'short percent triplet' => ['foo%2'],
+            'non-hex percent triplet' => ['foo%ZZ'],
+            'double quote' => ['foo"bar'],
+            'less-than' => ['foo<bar'],
+            'greater-than' => ['foo>bar'],
+            'backslash' => ['foo\bar'],
+            'caret' => ['foo^bar'],
+            'backtick' => ['foo`bar'],
+            'pipe' => ['foo|bar'],
+            'nul' => ["foo\x00bar"],
+            'crlf' => ["foo\r\nbar"],
+            'del' => ["foo\x7Fbar"],
+            'c1 control' => ["foo\xC2\x80bar"],
+            'invalid utf-8' => ["foo\xC3".'bar'],
+            'invalid after expression' => ['/{id}/bad path'],
+        ];
+    }
+
+    /**
+     * @dataProvider invalidLiteralProvider
+     */
+    public function testRejectsInvalidLiteralText(string $template): void
+    {
+        $this->assertInvalidTemplate($template, ['id' => 'a']);
+    }
+
     public static function reservedExpansionPctTripletProvider(): array
     {
         return [

--- a/tests/UriTemplateTest.php
+++ b/tests/UriTemplateTest.php
@@ -132,6 +132,7 @@ final class UriTemplateTest extends TestCase
             'no expressions' => ['foo', [], 'foo'],
             'expression with literal path' => ['/users/{id}', ['id' => '123'], '/users/123'],
             'pct encoded literal' => ['/files/%2F/{id}', ['id' => 'a'], '/files/%2F/a'],
+            'apostrophe literal' => ["/users/o'hara/{id}", ['id' => 'a'], "/users/o'hara/a"],
             'unicode literal' => ["/caf\xC3\xA9/{id}", ['id' => 'a'], '/caf%C3%A9/a'],
             'emoji literal' => ["/\xF0\x9F\x98\x80/{id}", ['id' => 'a'], '/%F0%9F%98%80/a'],
         ];


### PR DESCRIPTION
Validates literal URI template text, preserves valid pct-encoded triplets and apostrophe literals for upstream fixture compatibility, and pct-encodes valid non-ASCII literals during expansion.