### PR TITLE
Validate unsafe URI template literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 
 ### Changed
 - Invalid URI template syntax now throws `InvalidArgumentException` instead of being partially expanded or returned unchanged
+- Literal template text is now validated for unsafe characters
 - URI template variable names and modifiers are now validated according to RFC 6570
 - Prefix modifiers are now rejected for list and map values
 - Referenced variable values are now validated before expansion

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 
 ### Changed
 - Invalid URI template syntax now throws `InvalidArgumentException` instead of being partially expanded or returned unchanged
-- Literal template text is now validated for unsafe characters
+- Literal template text is now validated for unsafe characters, including malformed percent sequences and control or format characters
 - URI template variable names and modifiers are now validated according to RFC 6570
 - Prefix modifiers are now rejected for list and map values
 - Referenced variable values are now validated before expansion

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -26,10 +26,10 @@ specifiers, and prefix modifiers applied to list or map values.
 #### Literal Text
 
 Literal text outside expressions is now validated for unsafe characters. Spaces,
-raw or malformed `%` sequences, double quotes, controls, `<`, `>`, backslash,
-caret, backtick, and pipe now throw `InvalidArgumentException`. Valid non-ASCII
-literal text is preserved, but must be valid UTF-8. Templates without expressions
-are also validated.
+raw or malformed `%` sequences, double quotes, ASCII controls, Unicode control
+and format characters, `<`, `>`, backslash, caret, backtick, and pipe now throw
+`InvalidArgumentException`. Valid printable non-ASCII literal text is preserved,
+but must be valid UTF-8. Templates without expressions are also validated.
 
 Before:
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -23,6 +23,26 @@ Invalid template syntax includes malformed braces, unsupported operators,
 invalid variable names, invalid modifiers, repeated operator-like variable
 specifiers, and prefix modifiers applied to list or map values.
 
+#### Literal Text
+
+Literal text outside expressions is now validated for unsafe characters. Spaces,
+raw or malformed `%` sequences, double quotes, controls, `<`, `>`, backslash,
+caret, backtick, and pipe now throw `InvalidArgumentException`. Valid non-ASCII
+literal text is preserved, but must be valid UTF-8. Templates without expressions
+are also validated.
+
+Before:
+
+```php
+UriTemplate::expand('/search terms/{id}', ['id' => 1]);
+```
+
+After:
+
+```php
+UriTemplate::expand('/search%20terms/{id}', ['id' => 1]);
+```
+
 #### Variable Names
 
 Variable names in templates must use RFC 6570 syntax: ASCII letters, ASCII

--- a/src/UriTemplate.php
+++ b/src/UriTemplate.php
@@ -38,7 +38,7 @@ final class UriTemplate
      */
     public static function expand(string $template, array $variables): string
     {
-        self::validateTemplateStructure($template);
+        self::validateTemplate($template);
 
         if (false === \strpos($template, '{')) {
             return $template;
@@ -70,14 +70,17 @@ final class UriTemplate
         };
     }
 
-    private static function validateTemplateStructure(string $template): void
+    private static function validateTemplate(string $template): void
     {
         $length = \strlen($template);
+        $literalStart = 0;
 
         for ($offset = 0; $offset < $length; ++$offset) {
             $char = $template[$offset];
 
             if ($char === '{') {
+                self::validateLiteralSegment(\substr($template, $literalStart, $offset - $literalStart), $literalStart);
+
                 $end = \strpos($template, '}', $offset + 1);
 
                 if ($end === false) {
@@ -95,6 +98,8 @@ final class UriTemplate
                 }
 
                 $offset = $end;
+                $literalStart = $end + 1;
+
                 continue;
             }
 
@@ -102,6 +107,8 @@ final class UriTemplate
                 throw self::invalidTemplate($offset, 'unmatched "}"');
             }
         }
+
+        self::validateLiteralSegment(\substr($template, $literalStart), $literalStart);
     }
 
     private static function invalidTemplate(int $offset, string $message): \InvalidArgumentException
@@ -528,6 +535,64 @@ final class UriTemplate
         }
 
         return \implode('', \array_slice($matches[0], 0, $length));
+    }
+
+    private static function validateLiteralSegment(string $literal, int $baseOffset): void
+    {
+        if ($literal === '') {
+            return;
+        }
+
+        $matches = [];
+        $result = \preg_match_all('/%[0-9A-Fa-f]{2}|./us', $literal, $matches, \PREG_OFFSET_CAPTURE);
+
+        if ($result === false || \preg_last_error() !== \PREG_NO_ERROR) {
+            throw self::invalidTemplate($baseOffset, 'literal text must be valid UTF-8');
+        }
+
+        $position = 0;
+
+        foreach ($matches[0] as $match) {
+            $token = $match[0];
+            $offset = $match[1];
+
+            if ($offset < 0) {
+                throw self::invalidTemplate($baseOffset + $position, 'invalid literal character');
+            }
+
+            if ($offset !== $position) {
+                throw self::invalidTemplate($baseOffset + $position, 'invalid literal character');
+            }
+
+            $position = $offset + \strlen($token);
+
+            if (\preg_match('/\A%[0-9A-Fa-f]{2}\z/', $token) === 1) {
+                continue;
+            }
+
+            if (\strlen($token) === 1) {
+                if (self::isAllowedLiteralByte($token)) {
+                    continue;
+                }
+
+                throw self::invalidTemplate($baseOffset + $offset, $token === '%' ? 'invalid percent-encoded triplet' : 'invalid literal character');
+            }
+        }
+
+        if ($position !== \strlen($literal)) {
+            throw self::invalidTemplate($baseOffset + $position, 'invalid literal character');
+        }
+    }
+
+    private static function isAllowedLiteralByte(string $char): bool
+    {
+        $ord = \ord($char);
+
+        if ($ord < 0x21 || $ord === 0x7F) {
+            return false;
+        }
+
+        return \strpos('"%<>\\^`|', $char) === false;
     }
 
     private static function encodeValue(string $value, bool $allowReserved): string

--- a/src/UriTemplate.php
+++ b/src/UriTemplate.php
@@ -577,6 +577,10 @@ final class UriTemplate
 
                 throw self::invalidTemplate($baseOffset + $offset, $token === '%' ? 'invalid percent-encoded triplet' : 'invalid literal character');
             }
+
+            if (self::isUnsafeUnicodeLiteral($token)) {
+                throw self::invalidTemplate($baseOffset + $offset, 'invalid literal character');
+            }
         }
 
         if ($position !== \strlen($literal)) {
@@ -593,6 +597,11 @@ final class UriTemplate
         }
 
         return \strpos('"%<>\\^`|', $char) === false;
+    }
+
+    private static function isUnsafeUnicodeLiteral(string $char): bool
+    {
+        return \preg_match('/\A[\p{Cc}\p{Cf}]\z/u', $char) === 1;
     }
 
     private static function encodeValue(string $value, bool $allowReserved): string

--- a/tests/UriTemplateTest.php
+++ b/tests/UriTemplateTest.php
@@ -163,6 +163,10 @@ final class UriTemplateTest extends TestCase
             'nul' => ["foo\x00bar"],
             'crlf' => ["foo\r\nbar"],
             'del' => ["foo\x7Fbar"],
+            'c1 control' => ["foo\xC2\x80bar"],
+            'zero-width space' => ["foo\xE2\x80\x8Bbar"],
+            'right-to-left override' => ["foo\xE2\x80\xAEbar"],
+            'byte order mark' => ["foo\xEF\xBB\xBFbar"],
             'invalid utf-8' => ["foo\xC3".'bar'],
             'invalid after expression' => ['/{id}/bad path'],
         ];

--- a/tests/UriTemplateTest.php
+++ b/tests/UriTemplateTest.php
@@ -126,6 +126,56 @@ final class UriTemplateTest extends TestCase
         self::assertSame($expansion, UriTemplate::expand($template, $variables));
     }
 
+    public static function safeLiteralProvider(): array
+    {
+        return [
+            'no expressions' => ['foo', [], 'foo'],
+            'expression with literal path' => ['/users/{id}', ['id' => '123'], '/users/123'],
+            'pct encoded literal' => ['/files/%2F/{id}', ['id' => 'a'], '/files/%2F/a'],
+            'apostrophe literal' => ["/users/o'hara/{id}", ['id' => 'a'], "/users/o'hara/a"],
+            'unicode literal preserved' => ["/caf\xC3\xA9/{id}", ['id' => 'a'], "/caf\xC3\xA9/a"],
+            'emoji literal preserved' => ["/\xF0\x9F\x98\x80/{id}", ['id' => 'a'], "/\xF0\x9F\x98\x80/a"],
+        ];
+    }
+
+    /**
+     * @dataProvider safeLiteralProvider
+     */
+    public function testExpandsSafeLiteralText(string $template, array $variables, string $expansion): void
+    {
+        self::assertSame($expansion, UriTemplate::expand($template, $variables));
+    }
+
+    public static function unsafeLiteralProvider(): array
+    {
+        return [
+            'space' => ['foo bar'],
+            'trailing percent' => ['foo%'],
+            'short percent triplet' => ['foo%2'],
+            'non-hex percent triplet' => ['foo%ZZ'],
+            'double quote' => ['foo"bar'],
+            'less-than' => ['foo<bar'],
+            'greater-than' => ['foo>bar'],
+            'backslash' => ['foo\bar'],
+            'caret' => ['foo^bar'],
+            'backtick' => ['foo`bar'],
+            'pipe' => ['foo|bar'],
+            'nul' => ["foo\x00bar"],
+            'crlf' => ["foo\r\nbar"],
+            'del' => ["foo\x7Fbar"],
+            'invalid utf-8' => ["foo\xC3".'bar'],
+            'invalid after expression' => ['/{id}/bad path'],
+        ];
+    }
+
+    /**
+     * @dataProvider unsafeLiteralProvider
+     */
+    public function testRejectsUnsafeLiteralText(string $template): void
+    {
+        $this->assertInvalidTemplate($template, ['id' => 'a']);
+    }
+
     public static function reservedExpansionPctTripletProvider(): array
     {
         return [


### PR DESCRIPTION
Rejects unsafe literal URI template text, including malformed percent sequences and control or format characters, while preserving existing printable non-ASCII literal output behavior.