### PR TITLE
Remove backported pct triplet upgrade note

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -110,8 +110,6 @@ prefixed string value must be valid UTF-8, otherwise expansion throws
 
 Reserved expansion (`{+var}`) and fragment expansion (`{#var}`) intentionally
 preserve URI reserved delimiters from variable values according to RFC 6570.
-They also preserve valid pct-encoded triplets already present in variable
-values.
 
 Templates should generally be application-controlled. If templates come from
 users or remote systems, treat them as policy input and review them before


### PR DESCRIPTION
Removes upgrade-guide wording for reserved and fragment pct-triplet preservation now that the behavior is available on 1.x.