### PR TITLE
Fix nested query key encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 ## v1.0.6 - Unreleased
 
 ### Fixed
+- Fixed nested query array keys being double-encoded during exploded query expansion
 - Fixed reserved and fragment expansion preserving existing pct-encoded triplets in variable values
 
 ## v1.0.5 - 2025-08-22

--- a/src/UriTemplate.php
+++ b/src/UriTemplate.php
@@ -95,7 +95,8 @@ final class UriTemplate
                 /** @var mixed $var */
                 foreach ($variable as $key => $var) {
                     if ($isAssoc) {
-                        $key = \rawurlencode((string) $key);
+                        $rawKey = (string) $key;
+                        $key = \rawurlencode($rawKey);
                         $isNestedArray = \is_array($var);
                     } else {
                         $isNestedArray = false;
@@ -109,7 +110,7 @@ final class UriTemplate
                         if ($isAssoc) {
                             if ($isNestedArray) {
                                 // Nested arrays must allow for deeply nested structures.
-                                $var = \http_build_query([$key => $var], '', '&', \PHP_QUERY_RFC3986);
+                                $var = \http_build_query([$rawKey => $var], '', '&', \PHP_QUERY_RFC3986);
                             } else {
                                 $var = \sprintf('%s=%s', (string) $key, (string) $var);
                             }

--- a/tests/UriTemplateTest.php
+++ b/tests/UriTemplateTest.php
@@ -201,6 +201,50 @@ final class UriTemplateTest extends TestCase
         self::assertSame($data, $method->invokeArgs($template, [$exp]));
     }
 
+    public static function nestedQueryKeyEncodingProvider(): array
+    {
+        return [
+            'space in nested top-level key' => [
+                '{?x*}',
+                ['x' => ['a b' => ['c' => 'd']]],
+                '?a%20b%5Bc%5D=d',
+            ],
+            'reserved slash in nested top-level key' => [
+                '{?x*}',
+                ['x' => ['a/b' => ['c' => 'd']]],
+                '?a%2Fb%5Bc%5D=d',
+            ],
+            'percent triplet text in nested top-level key' => [
+                '{?x*}',
+                ['x' => ['a%2Fb' => ['c' => 'd']]],
+                '?a%252Fb%5Bc%5D=d',
+            ],
+            'space in nested child key and value' => [
+                '{?x*}',
+                ['x' => ['a b' => ['c d' => 'e f']]],
+                '?a%20b%5Bc%20d%5D=e%20f',
+            ],
+            'continuation operator nested key' => [
+                '{&x*}',
+                ['x' => ['a b' => ['c d' => 'e f']]],
+                '&a%20b%5Bc%20d%5D=e%20f',
+            ],
+            'scalar map key remains encoded' => [
+                '{?x*}',
+                ['x' => ['a b' => 'c d']],
+                '?a%20b=c%20d',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider nestedQueryKeyEncodingProvider
+     */
+    public function testNestedQueryKeysAreEncodedOnce(string $template, array $variables, string $expansion): void
+    {
+        self::assertSame($expansion, UriTemplate::expand($template, $variables));
+    }
+
     /**
      * @ticket https://github.com/guzzle/guzzle/issues/90
      */


### PR DESCRIPTION
Fixes nested exploded query expansion so map keys are encoded only once.