### PR TITLE
Skip empty nested query arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 ## v1.0.6 - Unreleased
 
 ### Fixed
+- Fixed empty nested arrays adding empty components to exploded query expansions
 - Fixed nested query array keys being double-encoded during exploded query expansion
 - Fixed reserved and fragment expansion preserving existing pct-encoded triplets in variable values
 

--- a/src/UriTemplate.php
+++ b/src/UriTemplate.php
@@ -111,6 +111,9 @@ final class UriTemplate
                             if ($isNestedArray) {
                                 // Nested arrays must allow for deeply nested structures.
                                 $var = \http_build_query([$rawKey => $var], '', '&', \PHP_QUERY_RFC3986);
+                                if ($var === '') {
+                                    continue;
+                                }
                             } else {
                                 $var = \sprintf('%s=%s', (string) $key, (string) $var);
                             }
@@ -123,8 +126,8 @@ final class UriTemplate
                     $kvp[$key] = $var;
                 }
 
-                if (0 === \count($variable)) {
-                    $actuallyUseQuery = false;
+                if ($kvp === []) {
+                    continue;
                 } elseif ($value['modifier'] === '*') {
                     $expanded = \implode($joiner, $kvp);
                     if ($isAssoc) {

--- a/tests/UriTemplateTest.php
+++ b/tests/UriTemplateTest.php
@@ -245,6 +245,55 @@ final class UriTemplateTest extends TestCase
         self::assertSame($expansion, UriTemplate::expand($template, $variables));
     }
 
+    public static function emptyNestedQueryArrayProvider(): array
+    {
+        return [
+            'empty nested array before scalar sibling' => [
+                '{?x*}',
+                ['x' => ['empty' => [], 'b' => 'c']],
+                '?b=c',
+            ],
+            'empty nested array after scalar sibling' => [
+                '{?x*}',
+                ['x' => ['b' => 'c', 'empty' => []]],
+                '?b=c',
+            ],
+            'continuation operator empty nested array' => [
+                '{&x*}',
+                ['x' => ['empty' => [], 'b' => 'c']],
+                '&b=c',
+            ],
+            'all nested arrays empty' => [
+                '{?x*}',
+                ['x' => ['a' => [], 'b' => []]],
+                '',
+            ],
+            'empty nested array before next variable' => [
+                '{?x*,y}',
+                ['x' => ['empty' => []], 'y' => 'c'],
+                '?y=c',
+            ],
+            'empty nested array after non-empty nested array' => [
+                '{?x*}',
+                ['x' => ['a' => ['b' => 'c'], 'empty' => []]],
+                '?a%5Bb%5D=c',
+            ],
+            'empty scalar value is preserved' => [
+                '{?x*}',
+                ['x' => ['empty' => '', 'nested' => []]],
+                '?empty=',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider emptyNestedQueryArrayProvider
+     */
+    public function testSkipsEmptyNestedQueryArrays(string $template, array $variables, string $expansion): void
+    {
+        self::assertSame($expansion, UriTemplate::expand($template, $variables));
+    }
+
     /**
      * @ticket https://github.com/guzzle/guzzle/issues/90
      */


### PR DESCRIPTION
Skips empty nested array expansions so exploded query maps do not emit empty query components.