### PR TITLE
Make UriTemplate non-instantiable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 - Prefix modifiers are now rejected for list and map values
 - Referenced variable values are now validated before expansion
 - Dense zero-indexed arrays are expanded as lists, and sparse or mixed-key arrays are expanded as maps
+- `UriTemplate` is now non-instantiable; use `UriTemplate::expand()` statically
 
 ### Fixed
 - Fixed invalid template expressions being accepted as parameter names in query and path-style parameter expansions

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -396,3 +396,8 @@ UriTemplate::expand('{+id}', ['id' => 'admin%2F']);
 Templates should generally be application-controlled. If templates come from
 users or remote systems, treat them as policy input because template syntax
 controls the structure of the expanded URI.
+
+#### UriTemplate Instantiation
+
+`UriTemplate` now has a private constructor. Use `UriTemplate::expand()`
+statically instead of instantiating the class.

--- a/src/UriTemplate.php
+++ b/src/UriTemplate.php
@@ -32,6 +32,10 @@ final class UriTemplate
         '&' => ['prefix' => '&', 'joiner' => '&', 'query' => true],
     ];
 
+    private function __construct()
+    {
+    }
+
     /**
      * @param array<string,mixed> $variables Variables to use in the template expansion
      *

--- a/tests/UriTemplateTest.php
+++ b/tests/UriTemplateTest.php
@@ -599,9 +599,7 @@ final class UriTemplateTest extends TestCase
      */
     public function testParsesExpressions(string $exp, array $data): void
     {
-        $template = new UriTemplate();
-
-        $class = new \ReflectionClass($template);
+        $class = new \ReflectionClass(UriTemplate::class);
 
         $method = $class->getMethod('parseExpression');
 
@@ -611,7 +609,7 @@ final class UriTemplateTest extends TestCase
 
         $exp = \substr($exp, 1, -1);
 
-        self::assertSame($data, $method->invokeArgs($template, [$exp]));
+        self::assertSame($data, $method->invokeArgs(null, [$exp]));
     }
 
     public static function nestedQueryKeyEncodingProvider(): array


### PR DESCRIPTION
This makes UriTemplate non-instantiable and updates the internal reflection test accordingly. The public API is the static UriTemplate::expand() method.