### PR TITLE
Fix omitted operator prefix for defined empty values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to `uri-template` will be documented in this file.
 
 Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) principles.
 
+## v1.0.7 - Upcoming
+
+### Fixed
+- Fixed the operator's leading character being omitted when defined variables expand to empty strings
+
 ## v1.0.6 - 2026-05-23
 
 ### Fixed

--- a/src/UriTemplate.php
+++ b/src/UriTemplate.php
@@ -78,7 +78,7 @@ final class UriTemplate
         $joiner = self::$operatorHash[$parsed['operator']]['joiner'];
         $useQuery = self::$operatorHash[$parsed['operator']]['query'];
         $allowReserved = $parsed['operator'] === '+' || $parsed['operator'] === '#';
-        $allUndefined = true;
+        $hasDefinedVariable = false;
 
         foreach ($parsed['values'] as $value) {
             if (!isset($variables[$value['value']])) {
@@ -148,7 +148,6 @@ final class UriTemplate
                     $expanded = \implode(',', $kvp);
                 }
             } else {
-                $allUndefined = false;
                 if ($value['modifier'] === ':' && isset($value['position'])) {
                     $variable = \substr((string) $variable, 0, $value['position']);
                 }
@@ -163,20 +162,18 @@ final class UriTemplate
                 }
             }
 
+            $hasDefinedVariable = true;
+
             $replacements[] = $expanded;
         }
 
         $ret = \implode($joiner, $replacements);
 
-        if ('' === $ret) {
-            // Spec section 3.2.4 and 3.2.5
-            if (false === $allUndefined && ('#' === $prefix || '.' === $prefix)) {
-                return $prefix;
-            }
-        } else {
-            if ('' !== $prefix) {
-                return \sprintf('%s%s', $prefix, $ret);
-            }
+        // Spec section 3.2.1 and appendix A: the operator's first string is
+        // appended once any variable in the expression is defined, even when
+        // every defined value expands to an empty string.
+        if ('' !== $prefix && $hasDefinedVariable) {
+            return \sprintf('%s%s', $prefix, $ret);
         }
 
         return $ret;

--- a/tests/UriTemplateTest.php
+++ b/tests/UriTemplateTest.php
@@ -30,6 +30,7 @@ final class UriTemplateTest extends TestCase
                 'comma' => ',',
             ],
             'empty_keys' => [],
+            'empty_member_list' => [''],
         ];
 
         return \array_map(static function ($t) use ($variables) {
@@ -109,6 +110,15 @@ final class UriTemplateTest extends TestCase
             ['{.null,var}',        '.value'],
             ['X{.empty_keys*}',     'X'],
             ['X{.empty_keys}',      'X'],
+            ['{/empty}',            '/'],
+            ['{empty_member_list}', ''],
+            ['{+empty_member_list}', ''],
+            ['{#empty_member_list}', '#'],
+            ['X{.empty_member_list}', 'X.'],
+            ['{/empty_member_list}', '/'],
+            ['{/empty_member_list*}', '/'],
+            ['X{.empty_member_list*}', 'X.'],
+            ['{#null,empty_member_list}', '#'],
             // Test that missing expansions are skipped
             ['test{&missing*}',     'test'],
             // Test that multiple expansions can be set


### PR DESCRIPTION
This fixes an RFC 6570 conformance bug where the operator's leading character was omitted whenever every defined variable in an expression expanded to an empty string. For example, `{/empty}` with `empty` set to an empty string expanded to an empty string instead of `/`, and `{#list}`, `{.list}`, and `{/list}` with a list containing a single empty string lost their `#`, `.`, and `/` prefixes entirely.

Section 3.2.6 of the RFC instructs the processor to append a slash for each defined variable before performing variable expansion, and its example table includes `{/var,empty}` expanding to `/value/`, which this library already gets right. Section 3.2.4 likewise appends the crosshatch if any of the variables are defined, and appendix A describes the first string as something to append once any of the expression's variables are defined. An empty string is a defined value under section 2.3, and a list containing an empty string has a member and is therefore also defined. The previous implementation only restored the prefix for the `#` and `.` operators, and only when the defined value was a scalar, which made `{/empty}` inconsistent with `{/var,empty}` and made `{#empty}` behave differently from `{#list}` with a single empty member.

The fix tracks whether any referenced variable contributed a defined value, including composite values, and appends the operator's first string whenever that is the case, even if the joined expansion is empty. Undefined variables, empty arrays, and expressions whose variables are all undefined continue to suppress the prefix, so templates with entirely missing data expand exactly as before. Python's uritemplate, the url-template package for JavaScript, and Ruby's addressable already produce the corrected output, so this change also improves interoperability across languages.

The scope of this fix is deliberately limited to the prefix emission bug. The other known RFC 6570 deviations in the 1.x line, such as the rendering of empty exploded members under the semicolon operator and the encoding of map keys under reserved and fragment expansion, are intentionally left unchanged here and are addressed on the 2.0 branch.