### PR TITLE
Apply ifemp to exploded named members

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 - Fixed invalid template expressions being accepted as parameter names in query and path-style expansions
 - Fixed prefix modifiers counting bytes instead of Unicode code points and pct-encoded triplets
 - Fixed unsupported variable shapes producing PHP warnings, conversion errors, or lossy `Array` output
+- Fixed path-style parameter explode rendering empty members as `name=` instead of bare `name`
 
 ### Removed
 - Dropped support for PHP 7.2 and 7.3

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3,7 +3,7 @@ parameters:
 		-
 			message: '#^Cannot cast array\<mixed, mixed\>\|string to string\.$#'
 			identifier: cast.string
-			count: 1
+			count: 3
 			path: src/UriTemplate.php
 
 		-

--- a/src/UriTemplate.php
+++ b/src/UriTemplate.php
@@ -19,17 +19,17 @@ final class UriTemplate
     /**
      * Hash for quick operator lookups.
      *
-     * @var array<string, array{prefix:string, joiner:string, query:bool}>
+     * @var array<string, array{prefix:string, joiner:string, query:bool, ifemp:string}>
      */
     private const OPERATOR_HASH = [
-        '' => ['prefix' => '', 'joiner' => ',', 'query' => false],
-        '+' => ['prefix' => '', 'joiner' => ',', 'query' => false],
-        '#' => ['prefix' => '#', 'joiner' => ',', 'query' => false],
-        '.' => ['prefix' => '.', 'joiner' => '.', 'query' => false],
-        '/' => ['prefix' => '/', 'joiner' => '/', 'query' => false],
-        ';' => ['prefix' => ';', 'joiner' => ';', 'query' => true],
-        '?' => ['prefix' => '?', 'joiner' => '&', 'query' => true],
-        '&' => ['prefix' => '&', 'joiner' => '&', 'query' => true],
+        '' => ['prefix' => '', 'joiner' => ',', 'query' => false, 'ifemp' => ''],
+        '+' => ['prefix' => '', 'joiner' => ',', 'query' => false, 'ifemp' => ''],
+        '#' => ['prefix' => '#', 'joiner' => ',', 'query' => false, 'ifemp' => ''],
+        '.' => ['prefix' => '.', 'joiner' => '.', 'query' => false, 'ifemp' => ''],
+        '/' => ['prefix' => '/', 'joiner' => '/', 'query' => false, 'ifemp' => ''],
+        ';' => ['prefix' => ';', 'joiner' => ';', 'query' => true, 'ifemp' => ''],
+        '?' => ['prefix' => '?', 'joiner' => '&', 'query' => true, 'ifemp' => '='],
+        '&' => ['prefix' => '&', 'joiner' => '&', 'query' => true, 'ifemp' => '='],
     ];
 
     private function __construct()
@@ -151,6 +151,7 @@ final class UriTemplate
         $prefix = self::OPERATOR_HASH[$parsed['operator']]['prefix'];
         $joiner = self::OPERATOR_HASH[$parsed['operator']]['joiner'];
         $useQuery = self::OPERATOR_HASH[$parsed['operator']]['query'];
+        $ifemp = self::OPERATOR_HASH[$parsed['operator']]['ifemp'];
         $allowReserved = $parsed['operator'] === '+' || $parsed['operator'] === '#';
         $hasDefinedVariable = false;
 
@@ -195,37 +196,34 @@ final class UriTemplate
                                 if ($var === '') {
                                     continue;
                                 }
+                            } elseif ($useQuery) {
+                                $var = self::formatPair((string) $key, (string) $var, $ifemp);
                             } else {
                                 $var = \sprintf('%s=%s', (string) $key, (string) $var);
                             }
-                        } elseif ($key > 0 && $actuallyUseQuery) {
-                            $var = \sprintf('%s=%s', $value['value'], (string) $var);
+                        } elseif ($useQuery) {
+                            $var = self::formatPair($value['value'], (string) $var, $ifemp);
                         }
+                    } elseif ($isAssoc) {
+                        // When an associative array is encountered and the
+                        // explode modifier is not set, then the result must be
+                        // a comma separated list of keys followed by their
+                        // respective values.
+                        $var = \sprintf('%s,%s', (string) $key, (string) $var);
                     }
 
-                    /** @var string $var */
-                    $kvp[$key] = $var;
+                    $kvp[] = (string) $var;
                 }
 
                 if ($kvp === []) {
                     continue;
                 } elseif ($value['modifier'] === '*') {
                     $expanded = \implode($joiner, $kvp);
-                    if ($isAssoc) {
-                        // Don't prepend the value name when using the explode
-                        // modifier with an associative array.
-                        $actuallyUseQuery = false;
-                    }
+                    // Spec appendix A: exploded members carry their own name
+                    // (and ifemp handling) above, so the expression-level
+                    // name must not be prepended again.
+                    $actuallyUseQuery = false;
                 } else {
-                    if ($isAssoc) {
-                        // When an associative array is encountered and the
-                        // explode modifier is not set, then the result must be
-                        // a comma separated list of keys followed by their
-                        // respective values.
-                        foreach ($kvp as $k => &$v) {
-                            $v = \sprintf('%s,%s', $k, $v);
-                        }
-                    }
                     $expanded = \implode(',', $kvp);
                 }
             } else {
@@ -237,11 +235,7 @@ final class UriTemplate
             }
 
             if ($actuallyUseQuery) {
-                if ($expanded === '' && $joiner !== '&') {
-                    $expanded = $value['value'];
-                } else {
-                    $expanded = \sprintf('%s=%s', $value['value'], $expanded);
-                }
+                $expanded = self::formatPair($value['value'], $expanded, $ifemp);
             }
 
             $hasDefinedVariable = true;
@@ -259,6 +253,22 @@ final class UriTemplate
         }
 
         return $ret;
+    }
+
+    /**
+     * Format a named (name, value) pair.
+     *
+     * Spec section 3.2.1: a pair whose value is the empty string is rendered
+     * as the name followed by the operator's ifemp string ("=" for the
+     * form-style "?" and "&" operators, nothing for ";").
+     */
+    private static function formatPair(string $name, string $value, string $ifemp): string
+    {
+        if ($value === '') {
+            return $name.$ifemp;
+        }
+
+        return \sprintf('%s=%s', $name, $value);
     }
 
     /**

--- a/tests/UriTemplateTest.php
+++ b/tests/UriTemplateTest.php
@@ -34,6 +34,8 @@ final class UriTemplateTest extends TestCase
             ],
             'empty_keys' => [],
             'empty_member_list' => [''],
+            'mixed_list' => ['red', ''],
+            'kv_empty' => ['a' => '', 'b' => 'x'],
         ];
 
         return \array_map(static function (array $t) use ($variables): array {
@@ -122,6 +124,12 @@ final class UriTemplateTest extends TestCase
             ['{/empty_member_list*}', '/'],
             ['X{.empty_member_list*}', 'X.'],
             ['{#null,empty_member_list}', '#'],
+            ['{;mixed_list*}',      ';mixed_list=red;mixed_list'],
+            ['{?mixed_list*}',      '?mixed_list=red&mixed_list='],
+            ['{&mixed_list*}',      '&mixed_list=red&mixed_list='],
+            ['{;kv_empty*}',        ';a;b=x'],
+            ['{?kv_empty*}',        '?a=&b=x'],
+            ['X{.kv_empty*}',       'X.a=.b=x'],
             // Test that missing expansions are skipped
             ['test{&missing*}',     'test'],
             // Test that multiple expansions can be set


### PR DESCRIPTION
This implements the ifemp rule from RFC 6570 for exploded composite values under the named operators. Section 3.2.1 states that an exploded pair with a defined value is appended as name=value or, if the value is the empty string and the expression type does not indicate form-style parameters, simply as the name, and the same section expands lists under the named operators as if each member were paired with the list's varname. Appendix A captures this as the ifemp string, which is empty for the semicolon operator and an equals sign for the question mark and ampersand operators. Previously, exploded members after the first were always rendered with a trailing equals sign, so `{;list*}` with the values red and an empty string produced `;list=red;list=` where the RFC requires `;list=red;list`, and `{;keys*}` with an empty map value produced `;a=` instead of `;a`. The first member was named through the expression-level prepend, whose emptiness test inspected the whole joined string rather than the member, so a leading empty member also came out wrong.

The operator table now carries the ifemp string for each operator, every exploded member under a named operator is named inline through a shared helper that applies the ifemp rule, and the expression-level prepend uses the same helper, replacing an equivalent but opaque joiner comparison. Because each member now carries its own name, the expression-level name is no longer prepended for any exploded value, and the member strings are collected as a plain list rather than keyed by the encoded member key, which also protects a later change to key encoding from silently dropping pairs whose distinct raw keys encode to the same string. Output for the question mark and ampersand operators is unchanged, since their ifemp string is the equals sign that was previously hardcoded, and all of the RFC's published examples for exploded lists and maps expand exactly as before.

It is worth noting that the corrected outputs differ from most other implementations, since league/uri, Python's uritemplate, the url-template package for JavaScript, and Ruby's addressable all render the affected members with a trailing equals sign. The normative text is unambiguous here, so this change follows the RFC rather than the ecosystem, and the affected inputs are limited to exploded members under the semicolon operator whose values are empty strings.