### PR TITLE
Encode pair names with the operator allow set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 - Fixed prefix modifiers counting bytes instead of Unicode code points and pct-encoded triplets
 - Fixed unsupported variable shapes producing PHP warnings, conversion errors, or lossy `Array` output
 - Fixed path-style parameter explode rendering empty members as `name=` instead of bare `name`
+- Fixed map keys not using the operator's allow set under reserved and fragment expansion
 
 ### Removed
 - Dropped support for PHP 7.2 and 7.3

--- a/src/UriTemplate.php
+++ b/src/UriTemplate.php
@@ -178,7 +178,11 @@ final class UriTemplate
                 foreach ($variable as $key => $var) {
                     if ($isAssoc) {
                         $rawKey = (string) $key;
-                        $key = \rawurlencode($rawKey);
+                        // Spec section 3.2.1: pair names are encoded in the
+                        // same way as simple string values, so reserved
+                        // expansion and fragment expansion keep reserved
+                        // characters and pct-encoded triplets in names.
+                        $key = self::encodeValue($rawKey, $allowReserved);
                         $isNestedArray = \is_array($var);
                     } else {
                         $isNestedArray = false;

--- a/tests/UriTemplateTest.php
+++ b/tests/UriTemplateTest.php
@@ -36,6 +36,7 @@ final class UriTemplateTest extends TestCase
             'empty_member_list' => [''],
             'mixed_list' => ['red', ''],
             'kv_empty' => ['a' => '', 'b' => 'x'],
+            'reserved_keys' => ['a/b' => 'c/d', 'x%20y' => 'v'],
         ];
 
         return \array_map(static function (array $t) use ($variables): array {
@@ -130,6 +131,11 @@ final class UriTemplateTest extends TestCase
             ['{;kv_empty*}',        ';a;b=x'],
             ['{?kv_empty*}',        '?a=&b=x'],
             ['X{.kv_empty*}',       'X.a=.b=x'],
+            ['{+reserved_keys}',    'a/b,c/d,x%20y,v'],
+            ['{+reserved_keys*}',   'a/b=c/d,x%20y=v'],
+            ['{#reserved_keys}',    '#a/b,c/d,x%20y,v'],
+            ['{#reserved_keys*}',   '#a/b=c/d,x%20y=v'],
+            ['{?reserved_keys*}',   '?a%2Fb=c%2Fd&x%2520y=v'],
             // Test that missing expansions are skipped
             ['test{&missing*}',     'test'],
             // Test that multiple expansions can be set
@@ -480,6 +486,7 @@ final class UriTemplateTest extends TestCase
             'list' => ['{/x*}', ['x' => ['red', 'green']], '/red/green'],
             'map' => ['{?x*}', ['x' => ['a' => 'b']], '?a=b'],
             'nested exploded map extension' => ['{?x*}', ['x' => ['a' => ['b' => 'c']]], '?a%5Bb%5D=c'],
+            'reserved key encoding collision keeps both pairs' => ['{+x*}', ['x' => ['a b' => '1', 'a%20b' => '2']], 'a%20b=1,a%20b=2'],
         ];
     }
 


### PR DESCRIPTION
This pull request fixes how map keys are percent-encoded under reserved expansion and fragment expansion. RFC 6570 section 3.2.1 states that both the name and value strings of a (name, value) pair are encoded in the same way as simple string values, and the encoding of a simple string value depends on the operator: under the + and # operators, characters in the unreserved set, the reserved set, and existing pct-encoded triplets pass through unencoded. The library previously encoded map keys with rawurlencode unconditionally, so a map such as ['a/b' => 'c/d'] expanded with {+keys*} produced a%2Fb=c/d instead of the correct a/b=c/d. Keys are now encoded with the same routine used for values, passing the operator's allow set, so reserved characters and pct-encoded triplets in keys are preserved under + and #. The named operators ?, & and ; are unchanged, because encoding a key with the unreserved allow set is byte-for-byte equivalent to rawurlencode, and the normative body text of section 3.2.1 takes precedence over the looser non-normative Appendix A wording for named operators. The nested query-array extension is also unaffected, since it builds its pairs from the raw key via http_build_query and only exists under the form-style operators. New test cases pin the corrected behaviour for both the explode and non-explode forms, the unchanged form-style encoding, and the case where two distinct raw keys encode to the same string under the wider allow set, which must keep both pairs in the output rather than silently collapsing them.