### PR TITLE
Skip null composite members as undefined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 - Referenced variable values are now validated before expansion
 - Dense zero-indexed arrays are expanded as lists, and sparse or mixed-key arrays are expanded as maps
 - `UriTemplate` is now non-instantiable; use `UriTemplate::expand()` statically
+- Nested null values in lists and maps are now treated as undefined members and omitted
 
 ### Fixed
 - Fixed invalid template expressions being accepted as parameter names in query and path-style expansions

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -72,8 +72,8 @@ UriTemplate::expand('{name:3}', ['name' => 'value']);
 ```
 
 Validate variable maps before expansion if they contain user-provided values.
-Unsupported resources, closures, non-stringable objects, nested null values, and
-unsupported nested arrays now throw `InvalidArgumentException`.
+Unsupported resources, closures, non-stringable objects, and unsupported nested
+arrays now throw `InvalidArgumentException`.
 
 Apply defaults before expansion instead of using non-RFC template extension
 syntax:
@@ -266,9 +266,12 @@ UriTemplate::expand('/search{?q,page}', [
 Nested arrays in maps are supported for exploded query-style expansions, such as
 `{?var*}` and `{&var*}`, to preserve existing Guzzle URI Template behavior.
 
+`null` members inside lists and maps are treated as undefined and omitted,
+consistent with top-level `null` and RFC 6570 section 2.4.2.
+
 Unsupported values throw `InvalidArgumentException` before expansion. This
 includes resources, closures, non-stringable objects, unsupported nested arrays,
-nested null values, recursive arrays, and arrays nested too deeply.
+recursive arrays, and arrays nested too deeply.
 
 Convert non-stringable objects before expansion:
 

--- a/docs/input-contract.md
+++ b/docs/input-contract.md
@@ -39,13 +39,17 @@ An empty string is a defined value and is expanded. An empty array is treated as
 undefined and omitted. Missing variables and variables set to `null` are treated
 as undefined and omitted.
 
+`null` members inside lists and maps are treated as undefined members and
+omitted, like top-level `null`. A list or map whose members are all `null` is
+treated as undefined and omitted, like an empty array.
+
 Dense zero-indexed arrays expand as lists. Sparse numeric arrays and mixed-key
 arrays expand as maps. Map and list order follows PHP array insertion order.
 
 Unsupported values include resources, closures, non-stringable objects,
-recursive arrays, arrays nested too deeply, nested `null` values, and nested
-arrays outside exploded query-style expansions. Unsupported values are validated
-only when the template references that variable.
+recursive arrays, arrays nested too deeply, and nested arrays outside exploded
+query-style expansions. Unsupported values are validated only when the template
+references that variable.
 
 ## Prefix Modifiers
 
@@ -75,8 +79,9 @@ exploded query or query-continuation expression, such as `{?filter*}` or
 `{&filter*}`.
 
 Nested query arrays must have scalar leaves. Recursive arrays, arrays nested too
-deeply, nested `null` values, and nested objects are rejected. Stringable objects
-are accepted as direct map values, but not as leaves inside nested query arrays.
+deeply, and nested objects are rejected. Nested `null` values are treated as
+undefined members and omitted. Stringable objects are accepted as direct map
+values, but not as leaves inside nested query arrays.
 
 Nested query arrays use RFC 3986 query encoding with PHP bracket syntax:
 

--- a/docs/uri-template-usage.md
+++ b/docs/uri-template-usage.md
@@ -157,7 +157,9 @@ UriTemplate::expand('/search{?filter*}', [
 // /search?author%5Bname%5D=Ada%20Lovelace
 ```
 
-Empty nested arrays are omitted from exploded query expansions.
+Empty nested arrays are omitted from exploded query expansions. `null` members
+inside lists and maps are treated as undefined members and omitted, like
+top-level `null`.
 
 Variable values are encoded during expansion according to the expression type.
 Existing percent-encoded triplets in reserved and fragment expansions are

--- a/src/UriTemplate.php
+++ b/src/UriTemplate.php
@@ -176,6 +176,12 @@ final class UriTemplate
                 $kvp = [];
                 /** @var mixed $var */
                 foreach ($variable as $key => $var) {
+                    if ($var === null) {
+                        // Spec sections 2.3 and 2.4.2: only members with
+                        // defined values are present in the expansion.
+                        continue;
+                    }
+
                     if ($isAssoc) {
                         $rawKey = (string) $key;
                         // Spec section 3.2.1: pair names are encoded in the
@@ -436,11 +442,7 @@ final class UriTemplate
         foreach ($value as $index => $member) {
             $memberPath = \sprintf('%s[%d]', $path, $index);
 
-            if ($member === null) {
-                throw self::invalidVariable($expression, $memberPath, 'nested null values are not supported');
-            }
-
-            if (self::isScalarLike($member)) {
+            if ($member === null || self::isScalarLike($member)) {
                 continue;
             }
 
@@ -469,11 +471,7 @@ final class UriTemplate
         foreach ($value as $key => $member) {
             $memberPath = \sprintf('%s[%s]', $path, (string) $key);
 
-            if ($member === null) {
-                throw self::invalidVariable($expression, $memberPath, 'nested null values are not supported');
-            }
-
-            if (self::isScalarLike($member)) {
+            if ($member === null || self::isScalarLike($member)) {
                 continue;
             }
 
@@ -502,11 +500,7 @@ final class UriTemplate
         foreach ($value as $key => $member) {
             $memberPath = \sprintf('%s[%s]', $path, (string) $key);
 
-            if ($member === null) {
-                throw self::invalidVariable($expression, $memberPath, 'nested null values are not supported');
-            }
-
-            if (\is_scalar($member)) {
+            if ($member === null || \is_scalar($member)) {
                 continue;
             }
 

--- a/tests/UriTemplateTest.php
+++ b/tests/UriTemplateTest.php
@@ -447,6 +447,7 @@ final class UriTemplateTest extends TestCase
             'map simple' => ['{keys:1}', ['keys' => ['semi' => ';']]],
             'reserved map' => ['{+keys:1}', ['keys' => ['semi' => ';']]],
             'matrix map' => ['{;keys:1}', ['keys' => ['semi' => ';']]],
+            'list with null member' => ['{x:1}', ['x' => ['red', null]]],
         ];
     }
 
@@ -487,6 +488,12 @@ final class UriTemplateTest extends TestCase
             'map' => ['{?x*}', ['x' => ['a' => 'b']], '?a=b'],
             'nested exploded map extension' => ['{?x*}', ['x' => ['a' => ['b' => 'c']]], '?a%5Bb%5D=c'],
             'reserved key encoding collision keeps both pairs' => ['{+x*}', ['x' => ['a b' => '1', 'a%20b' => '2']], 'a%20b=1,a%20b=2'],
+            'null list member skipped' => ['{?x*}', ['x' => ['a', null]], '?x=a'],
+            'null map member skipped' => ['{?x*}', ['x' => ['a' => null, 'b' => 'c']], '?b=c'],
+            'null member in simple list' => ['{x}', ['x' => ['red', null, 'blue']], 'red,blue'],
+            'all null map members undefined' => ['X{.x}', ['x' => ['a' => null]], 'X'],
+            'all null list members undefined' => ['{#x}', ['x' => [null]], ''],
+            'null nested query leaf skipped' => ['{?x*}', ['x' => ['a' => ['b' => null, 'c' => 'v']]], '?a%5Bc%5D=v'],
         ];
     }
 
@@ -517,8 +524,6 @@ final class UriTemplateTest extends TestCase
             'nested list in list' => ['{?x}', ['x' => [['a']]]],
             'nested array in unexploded map' => ['{?x}', ['x' => ['a' => ['b' => 'c']]]],
             'nested array in non-query exploded map' => ['{/x*}', ['x' => ['a' => ['b' => 'c']]]],
-            'nested null in list' => ['{?x*}', ['x' => ['a', null]]],
-            'nested null in map' => ['{?x*}', ['x' => ['a' => null]]],
             'nested object in query extension' => ['{?x*}', ['x' => ['a' => ['b' => new \stdClass()]]]],
         ];
     }


### PR DESCRIPTION
This pull request changes how null members inside lists and maps are handled during expansion. RFC 6570 section 2.4.2 states that if a variable has a composite structure and only some of the fields in that structure have defined values, then only the defined pairs are present in the expansion, and section 3.2.1 likewise appends each (name, value) pair that has a defined value. The library previously threw InvalidArgumentException for nested null values, which was also internally inconsistent, because a top-level null means the variable is undefined and is silently omitted while the very same null one level down was treated as an error. Null members in lists and maps are now skipped as undefined members, including null leaves inside the nested query-array extension, where PHP's http_build_query already drops null values natively, so the extension stays consistent with the rest of the pipeline. A list or map whose members are all null follows the existing empty-array path and is treated as undefined, meaning no operator prefix is emitted for it, which mirrors the rule in section 2.3 that a map variable without defined member values is undefined. Prefix modifiers remain invalid on composite values even when some of the members are null, and a new test pins that. The two existing rejection tests for nested nulls are replaced by expansion tests covering skipped list members, skipped map members, fully null composites under several operators, and null leaves in nested query arrays. The input contract, upgrade guide, and usage guide are updated in the same pull request, and the changelog records the behavioural change.