### PR TITLE
Require valid UTF-8 in variable values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 - Dense zero-indexed arrays are expanded as lists, and sparse or mixed-key arrays are expanded as maps
 - `UriTemplate` is now non-instantiable; use `UriTemplate::expand()` statically
 - Nested null values in lists and maps are now treated as undefined members and omitted
+- Variable values must now be valid UTF-8 and invalid byte sequences throw `InvalidArgumentException`
 
 ### Fixed
 - Fixed invalid template expressions being accepted as parameter names in query and path-style expansions

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -208,9 +208,10 @@ UriTemplate::expand('/search{?q}', ['q' => 'default']);
 
 Prefix modifiers, such as `{var:3}`, are valid only for scalar or stringable
 values. Prefix lengths must be positive integers from `1` through `9999`, with
-no leading zeroes. Prefix lengths are counted as Unicode code points and existing
-pct-encoded triplets, not bytes or visual grapheme clusters. A prefixed string
-value must be valid UTF-8, otherwise expansion throws `InvalidArgumentException`.
+no leading zeroes. Prefix lengths are counted as Unicode code points and
+existing pct-encoded triplets, not bytes or visual grapheme clusters. A prefixed
+string value must be valid UTF-8, otherwise expansion throws
+`InvalidArgumentException`.
 
 Before:
 
@@ -272,6 +273,10 @@ consistent with top-level `null` and RFC 6570 section 2.4.2.
 Unsupported values throw `InvalidArgumentException` before expansion. This
 includes resources, closures, non-stringable objects, unsupported nested arrays,
 recursive arrays, and arrays nested too deeply.
+
+Variable values must now be valid UTF-8. Invalid byte sequences throw
+`InvalidArgumentException` instead of being percent-encoded byte by byte. Encode
+binary data, for example with base64, before expansion.
 
 Convert non-stringable objects before expansion:
 

--- a/docs/input-contract.md
+++ b/docs/input-contract.md
@@ -51,6 +51,10 @@ recursive arrays, arrays nested too deeply, and nested arrays outside exploded
 query-style expansions. Unsupported values are validated only when the template
 references that variable.
 
+Variable values must be valid UTF-8. Invalid byte sequences throw
+`InvalidArgumentException`. Encode binary data, for example with base64, before
+expansion.
+
 ## Prefix Modifiers
 
 Prefix modifiers select a character prefix from scalar and stringable values:
@@ -70,7 +74,8 @@ varspec cannot combine prefix and explode modifiers.
 
 Prefix length counts Unicode characters and existing percent-encoded triplets,
 not bytes. For example, `%2F` counts as one character before the selected prefix
-is encoded for the expression type. Prefix selection requires valid UTF-8 input.
+is encoded for the expression type. Values must be valid UTF-8, as described in
+[values](#values).
 
 ## Nested Query Arrays
 

--- a/src/UriTemplate.php
+++ b/src/UriTemplate.php
@@ -188,14 +188,14 @@ final class UriTemplate
                         // same way as simple string values, so reserved
                         // expansion and fragment expansion keep reserved
                         // characters and pct-encoded triplets in names.
-                        $key = self::encodeValue($rawKey, $allowReserved);
+                        $key = self::encodeValue($rawKey, $allowReserved, $matches[1], $value['value']);
                         $isNestedArray = \is_array($var);
                     } else {
                         $isNestedArray = false;
                     }
 
                     if (!$isNestedArray) {
-                        $var = self::encodeValue((string) $var, $allowReserved);
+                        $var = self::encodeValue((string) $var, $allowReserved, $matches[1], $value['value']);
                     }
 
                     if ($value['modifier'] === '*') {
@@ -241,7 +241,7 @@ final class UriTemplate
                     $variable = self::prefixValue((string) $variable, $value['position'], $matches[1], $value['value']);
                 }
 
-                $expanded = self::encodeValue((string) $variable, $allowReserved);
+                $expanded = self::encodeValue((string) $variable, $allowReserved, $matches[1], $value['value']);
             }
 
             if ($actuallyUseQuery) {
@@ -500,7 +500,19 @@ final class UriTemplate
         foreach ($value as $key => $member) {
             $memberPath = \sprintf('%s[%s]', $path, (string) $key);
 
-            if ($member === null || \is_scalar($member)) {
+            if (\is_string($key) && \preg_match('//u', $key) !== 1) {
+                throw self::invalidVariable($expression, $memberPath, 'variable values must be valid UTF-8');
+            }
+
+            if ($member === null) {
+                continue;
+            }
+
+            if (\is_scalar($member)) {
+                if (\is_string($member) && \preg_match('//u', $member) !== 1) {
+                    throw self::invalidVariable($expression, $memberPath, 'variable values must be valid UTF-8');
+                }
+
                 continue;
             }
 
@@ -628,10 +640,16 @@ final class UriTemplate
         return \preg_match('/\A(?:[\x{A0}-\x{D7FF}\x{E000}-\x{FDCF}\x{FDF0}-\x{FFEF}]|[\x{10000}-\x{1FFFD}\x{20000}-\x{2FFFD}\x{30000}-\x{3FFFD}\x{40000}-\x{4FFFD}\x{50000}-\x{5FFFD}\x{60000}-\x{6FFFD}\x{70000}-\x{7FFFD}\x{80000}-\x{8FFFD}\x{90000}-\x{9FFFD}\x{A0000}-\x{AFFFD}\x{B0000}-\x{BFFFD}\x{C0000}-\x{CFFFD}\x{D0000}-\x{DFFFD}\x{E1000}-\x{EFFFD}\x{F0000}-\x{FFFFD}\x{100000}-\x{10FFFD}])\z/u', $char) === 1;
     }
 
-    private static function encodeValue(string $value, bool $allowReserved): string
+    private static function encodeValue(string $value, bool $allowReserved, string $expression, string $name): string
     {
         if ($value === '') {
             return '';
+        }
+
+        // Spec section 1.6: values are encoded as UTF-8 before pct-encoding,
+        // so byte sequences that are not valid UTF-8 cannot be expanded.
+        if (\preg_match('//u', $value) !== 1) {
+            throw self::invalidVariable($expression, $name, 'variable values must be valid UTF-8');
         }
 
         $matches = [];

--- a/tests/UriTemplateTest.php
+++ b/tests/UriTemplateTest.php
@@ -494,6 +494,7 @@ final class UriTemplateTest extends TestCase
             'all null map members undefined' => ['X{.x}', ['x' => ['a' => null]], 'X'],
             'all null list members undefined' => ['{#x}', ['x' => [null]], ''],
             'null nested query leaf skipped' => ['{?x*}', ['x' => ['a' => ['b' => null, 'c' => 'v']]], '?a%5Bc%5D=v'],
+            'valid multibyte value' => ['{x}', ['x' => "caf\xC3\xA9 \xF0\x9F\x98\x80"], 'caf%C3%A9%20%F0%9F%98%80'],
         ];
     }
 
@@ -525,6 +526,12 @@ final class UriTemplateTest extends TestCase
             'nested array in unexploded map' => ['{?x}', ['x' => ['a' => ['b' => 'c']]]],
             'nested array in non-query exploded map' => ['{/x*}', ['x' => ['a' => ['b' => 'c']]]],
             'nested object in query extension' => ['{?x*}', ['x' => ['a' => ['b' => new \stdClass()]]]],
+            'invalid utf-8 scalar' => ['{x}', ['x' => "\xC3"]],
+            'invalid utf-8 reserved scalar' => ['{+x}', ['x' => "\xC3"]],
+            'invalid utf-8 list member' => ['{x}', ['x' => ['ok', "\xC3"]]],
+            'invalid utf-8 map key' => ['{?x*}', ['x' => ["\xC3" => 'v']]],
+            'invalid utf-8 nested value' => ['{?x*}', ['x' => ['a' => ['b' => "\xC3"]]]],
+            'invalid utf-8 nested key' => ['{?x*}', ['x' => ['a' => ["\xC3" => 'v']]]],
         ];
     }
 


### PR DESCRIPTION
This pull request requires variable values to be valid UTF-8 before expansion. RFC 6570 section 1.6 states that a template processor must first encode the string as UTF-8 and then percent-encode any octets that are not allowed by the expression type, so percent-encoding an invalid byte sequence byte by byte cannot satisfy the specification. The 2.0 branch already rejects invalid UTF-8 in literal template text and in prefix-modified values, which left plain values, list and map members, map keys, and nested query-array leaves as the only remaining lenient paths, and this change closes them so the whole pipeline is uniformly strict. The encodeValue routine now validates its input and gains expression and variable name parameters so that the exception message identifies the failing variable in the same format as the existing shape errors, and assertNestedQueryShape additionally validates string keys and string leaves, since those bypass encodeValue and flow through http_build_query instead. The prefix-modifier path keeps its existing earlier check and more precise message, because it runs before encoding and already covered this case. Callers with binary data should encode it, for example with base64, before expansion. Six new rejection tests cover plain scalars, reserved expansion, list members, map keys, and nested query keys and leaves, and a new pin asserts that valid multibyte values, including an emoji, continue to expand byte for byte exactly as before. The input contract and upgrade guide are updated in the same pull request, and the changelog records the behavioural change.