### PR TITLE
Expand booleans as 1 and 0 at every nesting level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 - `UriTemplate` is now non-instantiable; use `UriTemplate::expand()` statically
 - Nested null values in lists and maps are now treated as undefined members and omitted
 - Variable values must now be valid UTF-8 and invalid byte sequences throw `InvalidArgumentException`
+- Booleans now expand as `1` and `0` at every nesting level
 
 ### Fixed
 - Fixed invalid template expressions being accepted as parameter names in query and path-style expansions

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -244,9 +244,10 @@ maps. `null` means undefined and is omitted from expansion. Lists and maps may
 contain scalar or stringable values. Dense zero-indexed arrays are expanded as
 lists. Sparse numeric arrays and mixed-key arrays are expanded as maps.
 
-Scalars are cast to strings using PHP's normal casting rules. In particular,
-`true` expands as `1` and `false` expands as an empty string. Use `null` when a
-variable should be omitted.
+Scalars are cast to strings before expansion. `true` expands as `1` and `false`
+expands as `0`, at every nesting level. Guzzle URI Template 1.x expanded
+top-level `false` as an empty string; pass `''` explicitly if that output is
+required, or `null` to omit the variable.
 
 ```php
 UriTemplate::expand('/search{?q,page}', [

--- a/docs/input-contract.md
+++ b/docs/input-contract.md
@@ -35,6 +35,8 @@ Supported variable values are:
 - maps containing scalar or stringable values
 - nested arrays in maps for exploded query-style expansions, with scalar leaves
 
+Booleans expand as `1` and `0` at every nesting level.
+
 An empty string is a defined value and is expanded. An empty array is treated as
 undefined and omitted. Missing variables and variables set to `null` are treated
 as undefined and omitted.

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -9,5 +9,5 @@ parameters:
 		-
 			message: '#^Cannot cast mixed to string\.$#'
 			identifier: cast.string
-			count: 3
+			count: 1
 			path: src/UriTemplate.php

--- a/src/UriTemplate.php
+++ b/src/UriTemplate.php
@@ -195,7 +195,7 @@ final class UriTemplate
                     }
 
                     if (!$isNestedArray) {
-                        $var = self::encodeValue((string) $var, $allowReserved, $matches[1], $value['value']);
+                        $var = self::encodeValue(self::stringifyValue($var), $allowReserved, $matches[1], $value['value']);
                     }
 
                     if ($value['modifier'] === '*') {
@@ -237,11 +237,13 @@ final class UriTemplate
                     $expanded = \implode(',', $kvp);
                 }
             } else {
+                $expanded = self::stringifyValue($variable);
+
                 if ($value['modifier'] === ':' && isset($value['position'])) {
-                    $variable = self::prefixValue((string) $variable, $value['position'], $matches[1], $value['value']);
+                    $expanded = self::prefixValue($expanded, $value['position'], $matches[1], $value['value']);
                 }
 
-                $expanded = self::encodeValue((string) $variable, $allowReserved, $matches[1], $value['value']);
+                $expanded = self::encodeValue($expanded, $allowReserved, $matches[1], $value['value']);
             }
 
             if ($actuallyUseQuery) {
@@ -263,6 +265,24 @@ final class UriTemplate
         }
 
         return $ret;
+    }
+
+    /**
+     * Cast a scalar or stringable variable value to its expansion string.
+     *
+     * Booleans expand as "1" and "0" so that false remains distinguishable
+     * from the empty string and matches the http_build_query semantics used
+     * by the nested query-array extension.
+     *
+     * @param mixed $value
+     */
+    private static function stringifyValue($value): string
+    {
+        if (\is_bool($value)) {
+            return $value ? '1' : '0';
+        }
+
+        return (string) $value;
     }
 
     /**

--- a/tests/UriTemplateTest.php
+++ b/tests/UriTemplateTest.php
@@ -477,7 +477,7 @@ final class UriTemplateTest extends TestCase
             'string' => ['{x}', ['x' => 'value'], 'value'],
             'int zero' => ['{x}', ['x' => 0], '0'],
             'float' => ['{x}', ['x' => 37.76], '37.76'],
-            'false' => ['{x}', ['x' => false], ''],
+            'false' => ['{x}', ['x' => false], '0'],
             'true' => ['{x}', ['x' => true], '1'],
             'empty string query' => ['{?x}', ['x' => ''], '?x='],
             'top-level null skipped' => ['{?x,y}', ['x' => null, 'y' => 'yes'], '?y=yes'],
@@ -495,6 +495,10 @@ final class UriTemplateTest extends TestCase
             'all null list members undefined' => ['{#x}', ['x' => [null]], ''],
             'null nested query leaf skipped' => ['{?x*}', ['x' => ['a' => ['b' => null, 'c' => 'v']]], '?a%5Bc%5D=v'],
             'valid multibyte value' => ['{x}', ['x' => "caf\xC3\xA9 \xF0\x9F\x98\x80"], 'caf%C3%A9%20%F0%9F%98%80'],
+            'false in query' => ['{?x}', ['x' => false], '?x=0'],
+            'bools in list' => ['{x}', ['x' => [true, false]], '1,0'],
+            'false in exploded map' => ['{?x*}', ['x' => ['a' => false]], '?a=0'],
+            'bools in nested query map' => ['{?x*}', ['x' => ['a' => ['b' => false, 'c' => true]]], '?a%5Bb%5D=0&a%5Bc%5D=1'],
         ];
     }
 


### PR DESCRIPTION
This pull request changes how boolean variable values expand. RFC 6570 has no boolean concept, so this is library contract rather than specification conformance, and the contract chosen is uniform: true expands as 1 and false expands as 0 at every nesting level. Previously a top-level false expanded as an empty string through PHP's native string cast, while a false leaf inside a nested query array expanded as 0 through http_build_query, so the same value produced different text depending on its nesting depth. The new stringifyValue helper centralises the casting, keeps false distinguishable from a genuinely empty string, and matches the http_build_query semantics already used by the nested query-array extension, which therefore needs no code change at all. Genuinely empty strings retain their ifemp behaviour, so {;empty} still renders as ;empty, and omission remains the job of null. This changes the expansion of top-level false from an empty string in 1.x to 0, which is a deliberate 2.0 contract change documented in the upgrade guide along with the migration advice to pass an empty string explicitly if the old output is required. The scalar branch is also reordered so that the prefix modifier slices the stringified value before encoding, with behaviour unchanged for every non-boolean value, and integer zero, floats, and true expand exactly as before. The existing false pin is updated, new tests cover false in queries, lists, exploded maps, and nested query maps, and the phpstan baseline is regenerated under PHP 7.4 because the casts moved into the new helper. The input contract and upgrade guide are updated in the same pull request, and the changelog records the behavioural change.