### PR TITLE
Document RFC 6570 conformance decisions

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -87,12 +87,12 @@ UriTemplate::expand('/search{?q}', ['q' => $q]);
 #### Literal Text
 
 Literal text outside expressions is now validated and encoded using RFC 6570
-literal rules, with apostrophes preserved for compatibility with upstream RFC
-example fixtures. Invalid literal characters, including spaces, raw or malformed
-`%` sequences, double quotes, controls, `<`, `>`, backslash, caret, backtick,
-and pipe, now throw `InvalidArgumentException`. Valid non-ASCII literal text
-must be valid UTF-8 and is pct-encoded during expansion. Templates without
-expressions are also validated and encoded.
+literal rules; apostrophes are valid literal characters per verified RFC 6570
+erratum 6937. Invalid literal characters, including spaces, raw or malformed `%`
+sequences, double quotes, controls, `<`, `>`, backslash, caret, backtick, and
+pipe, now throw `InvalidArgumentException`. Valid non-ASCII literal text must be
+valid UTF-8 and is pct-encoded during expansion. Templates without expressions
+are also validated and encoded.
 
 Existing valid pct-encoded triplets in literal text are preserved. Raw `%`
 characters and malformed pct-encoded triplets are invalid literal text.
@@ -241,8 +241,9 @@ UriTemplate::expand('{/list*}', [
 
 Supported variable values are `null`, scalars, stringable objects, lists, and
 maps. `null` means undefined and is omitted from expansion. Lists and maps may
-contain scalar or stringable values. Dense zero-indexed arrays are expanded as
-lists. Sparse numeric arrays and mixed-key arrays are expanded as maps.
+contain scalar or stringable values. Arrays whose keys are exactly `0` through
+`n-1` in ascending insertion order are expanded as lists. All other arrays,
+including reordered, sparse, and mixed-key arrays, are expanded as maps.
 
 Scalars are cast to strings before expansion. `true` expands as `1` and `false`
 expands as `0`, at every nesting level. Guzzle URI Template 1.x expanded
@@ -301,9 +302,10 @@ UriTemplate::expand('/events{?date}', [
 
 #### Array Values
 
-PHP arrays are classified by shape. Dense zero-indexed arrays are lists. Sparse
-numeric arrays and mixed-key arrays are maps. This makes expansion deterministic
-and preserves PHP insertion order for maps.
+PHP arrays are classified by shape. Arrays whose keys are exactly `0` through
+`n-1` in ascending insertion order are lists. All other arrays, including
+reordered, sparse, and mixed-key arrays, are maps. This makes expansion
+deterministic and preserves PHP insertion order for maps.
 
 If a sparse array is intended to be a list, reindex it before expansion:
 

--- a/docs/input-contract.md
+++ b/docs/input-contract.md
@@ -45,8 +45,9 @@ as undefined and omitted.
 omitted, like top-level `null`. A list or map whose members are all `null` is
 treated as undefined and omitted, like an empty array.
 
-Dense zero-indexed arrays expand as lists. Sparse numeric arrays and mixed-key
-arrays expand as maps. Map and list order follows PHP array insertion order.
+Arrays whose keys are exactly `0` through `n-1` in ascending insertion order
+expand as lists. All other arrays, including reordered, sparse, and mixed-key
+arrays, expand as maps. Map and list order follows PHP array insertion order.
 
 Unsupported values include resources, closures, non-stringable objects,
 recursive arrays, arrays nested too deeply, and nested arrays outside exploded
@@ -107,6 +108,9 @@ UriTemplate::expand('/search{?filter*}', [
 Empty nested arrays are omitted from exploded query expansions. Empty scalar
 values are preserved.
 
+Empty-string keys in nested query arrays produce PHP append syntax
+(`a%5B%5D=v`), which does not round-trip the key.
+
 ## Validation Errors
 
 Literal text outside expressions must already be valid URI template literal text.
@@ -115,6 +119,9 @@ For example, use `/search%20terms/{id}` instead of `/search terms/{id}`.
 `InvalidArgumentException` is thrown for invalid template syntax, unsupported
 operators, invalid variable names, invalid modifiers, invalid literal text, and
 unsupported shapes for variables referenced by the template.
+
+Exceptions thrown by a value object's `__toString()` method propagate unchanged;
+they are not converted to `InvalidArgumentException`.
 
 Catch `InvalidArgumentException` if templates or values come from outside your
 application:

--- a/docs/uri-template-usage.md
+++ b/docs/uri-template-usage.md
@@ -115,9 +115,10 @@ UriTemplate::expand('/tags{?tag*}', [
 // /tags?tag=red&tag=green
 ```
 
-[Dense zero-indexed arrays](input-contract.md#values) expand as lists. Sparse
-numeric arrays and mixed-key arrays expand as maps. Map order follows PHP array
-insertion order:
+[Arrays whose keys are exactly `0` through `n-1`](input-contract.md#values) in
+ascending insertion order expand as lists. All other arrays, including
+reordered, sparse, and mixed-key arrays, expand as maps. Map order follows PHP
+array insertion order:
 
 ```php
 UriTemplate::expand('/search{?filter*}', [
@@ -174,6 +175,29 @@ UriTemplate::expand('{+id}', ['id' => 'admin%2F']);
 
 // admin%2F
 ```
+
+## Specification Conformance Notes
+
+Prefix modifiers count existing percent-encoded triplets as one character. RFC
+6570 section 3.2.1 defines a prefix as the "first max-length characters of the
+decoded value" and forbids splitting a multi-octet or percent-encoded sequence.
+For example, `{id:1}` with the value `admin%2F` selects `a`. Several other
+implementations count raw characters instead and can split percent-encoded
+triplets, so prefixed expansions of values containing triplets can differ
+between libraries.
+
+Invalid templates and unsupported variable values throw
+`InvalidArgumentException`. RFC 6570 section 3 allows a template processor to
+recover from an error by copying the offending expression into the result, but
+describes such output as "only intended for diagnostic use". This library treats
+these conditions as errors instead of producing diagnostic output.
+
+Booleans expand as `1` and `0` at every nesting level, as described in the
+[input contract](input-contract.md#values).
+
+Variable values must be valid UTF-8, per RFC 6570 section 1.6. Invalid byte
+sequences throw `InvalidArgumentException`, as described in the [input
+contract](input-contract.md#values).
 
 ## Related
 

--- a/src/UriTemplate.php
+++ b/src/UriTemplate.php
@@ -644,7 +644,7 @@ final class UriTemplate
         return $ord === 0x21
             || ($ord >= 0x23 && $ord <= 0x24)
             || $ord === 0x26
-            // Upstream RFC example fixtures include apostrophes as literal text.
+            // Apostrophe is a valid literal per RFC 6570 erratum 6937 (verified).
             || $ord === 0x27
             || ($ord >= 0x28 && $ord <= 0x3B)
             || $ord === 0x3D


### PR DESCRIPTION
This pull request is documentation only and completes the RFC 6570 conformance series by recording the decisions that are deliberate library contract rather than accident. The justification for apostrophes in literal text, in both the source comment and the upgrade guide, previously appealed to compatibility with upstream RFC example fixtures; it now cites the actual authority, verified RFC 6570 erratum 6937, under which the apostrophe is simply a valid literal character. The list-versus-map classification wording in the input contract, the usage guide, and the upgrade guide is tightened from dense zero-indexed arrays to arrays whose keys are exactly 0 through n-1 in ascending insertion order, which is what the implementation actually checks, so reordered numeric keys now clearly fall on the map side. A new specification conformance notes section in the usage guide records that prefix modifiers count existing percent-encoded triplets as one character, quoting the definition in section 3.2.1 of a prefix as the first max-length characters of the decoded value and its rule against splitting percent-encoded sequences, with an interoperability note that several other implementations count raw characters instead and can split triplets. The same section records that invalid templates and unsupported values throw InvalidArgumentException rather than performing the optional error recovery described in section 3, whose output the RFC says is only intended for diagnostic use, and it cross-references the boolean and UTF-8 contracts established earlier in the series. The input contract gains two corner notes, namely that empty-string keys in nested query arrays produce PHP append syntax which does not round-trip the key, and that exceptions thrown by a value object's __toString method propagate unchanged. The README needed no changes, since none of its examples involve the behaviours this series changed, and there is no changelog entry because nothing here changes behaviour.