### PR TITLE
Treat all-null composites as undefined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 - Fixed unsupported variable shapes producing PHP warnings, conversion errors, or lossy `Array` output
 - Fixed path-style parameter explode rendering empty members as `name=` instead of bare `name`
 - Fixed map keys not using the operator's allow set under reserved and fragment expansion
+- Fixed all-null lists and maps throwing with prefix modifiers instead of being skipped as undefined
 
 ### Removed
 - Dropped support for PHP 7.2 and 7.3

--- a/src/UriTemplate.php
+++ b/src/UriTemplate.php
@@ -162,10 +162,6 @@ final class UriTemplate
 
             $variable = $variables[$value['value']];
 
-            if (\is_array($variable) && $variable === []) {
-                continue;
-            }
-
             self::assertVariableShape($value, $variable, $matches[1], $parsed['operator']);
 
             $actuallyUseQuery = $useQuery;
@@ -387,11 +383,35 @@ final class UriTemplate
     }
 
     /**
+     * Determines if a referenced variable is undefined.
+     *
+     * Spec section 2.3: a list is undefined when it contains zero members,
+     * and a map is undefined when it contains zero members or when all
+     * member names are associated with undefined values. Lists whose
+     * members are all null are treated the same way, like an empty list.
+     * Spec section 3.2.1: undefined variables are ignored by the expansion
+     * process, so they are skipped before varspec shape validation.
+     *
      * @param array<string,mixed> $variables
      */
     private static function isUndefinedVariable(array $variables, string $name): bool
     {
-        return !\array_key_exists($name, $variables) || $variables[$name] === null;
+        if (!\array_key_exists($name, $variables) || $variables[$name] === null) {
+            return true;
+        }
+
+        if (!\is_array($variables[$name])) {
+            return false;
+        }
+
+        /** @var mixed $member */
+        foreach ($variables[$name] as $member) {
+            if ($member !== null) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private static function invalidVariable(string $expression, string $path, string $message): \InvalidArgumentException

--- a/tests/UriTemplateTest.php
+++ b/tests/UriTemplateTest.php
@@ -448,6 +448,7 @@ final class UriTemplateTest extends TestCase
             'reserved map' => ['{+keys:1}', ['keys' => ['semi' => ';']]],
             'matrix map' => ['{;keys:1}', ['keys' => ['semi' => ';']]],
             'list with null member' => ['{x:1}', ['x' => ['red', null]]],
+            'map with null member' => ['{x:1}', ['x' => ['a' => null, 'b' => 'v']]],
         ];
     }
 
@@ -466,6 +467,31 @@ final class UriTemplateTest extends TestCase
         self::assertSame('', UriTemplate::expand('{missing:1}', []));
         self::assertSame('', UriTemplate::expand('{missing:1}', ['missing' => null]));
         self::assertSame('', UriTemplate::expand('{list:1}', ['list' => []]));
+    }
+
+    /**
+     * @return array<string,array{0:string, 1:array<string,mixed>, 2:string}>
+     */
+    public static function allNullCompositeProvider(): array
+    {
+        return [
+            'prefix on all null map' => ['{x:1}', ['x' => ['a' => null]], ''],
+            'prefix on all null list' => ['{x:1}', ['x' => [null]], ''],
+            'path prefix on all null list' => ['{/x:3}', ['x' => [null, null]], ''],
+            'query prefix on all null map' => ['{?x:2}', ['x' => ['a' => null]], ''],
+            'label prefix on all null map' => ['X{.x:1}', ['x' => ['a' => null]], 'X'],
+            'remaining variables still expand' => ['{x:1,y}', ['x' => ['a' => null], 'y' => 'v'], 'v'],
+        ];
+    }
+
+    /**
+     * @dataProvider allNullCompositeProvider
+     *
+     * @param array<string,mixed> $variables
+     */
+    public function testTreatsAllNullCompositesAsUndefined(string $template, array $variables, string $expansion): void
+    {
+        self::assertSame($expansion, UriTemplate::expand($template, $variables));
     }
 
     /**


### PR DESCRIPTION
RFC 6570 section 2.3 considers an associative array undefined when all of its member names are associated with undefined values, and section 3.2.1 requires undefined variables to be ignored by the expansion process. The input contract documents the same rule: a list or map whose members are all null is treated as undefined and omitted, like an empty array. However, the all-null determination currently happens after the variable shape is validated, so `{x:1}` with `['x' => ['a' => null]]` throws the prefix-on-composite error instead of expanding to an empty string, and takes any sibling varspecs in the same expression down with it, while `['x' => []]` already expands to an empty string. This moves the undefined-composite determination into `isUndefinedVariable()`, which runs before shape validation, and removes the now redundant empty-array short-circuit. Composites with at least one defined member still reject prefix modifiers.