### PR TITLE
Report PCRE engine failures as RuntimeException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 - Fixed path-style parameter explode rendering empty members as `name=` instead of bare `name`
 - Fixed map keys not using the operator's allow set under reserved and fragment expansion
 - Fixed all-null lists and maps throwing with prefix modifiers instead of being skipped as undefined
+- Fixed PCRE engine failures on very long variable names being reported as invalid template syntax
 
 ### Removed
 - Dropped support for PHP 7.2 and 7.3

--- a/docs/input-contract.md
+++ b/docs/input-contract.md
@@ -120,6 +120,11 @@ For example, use `/search%20terms/{id}` instead of `/search terms/{id}`.
 operators, invalid variable names, invalid modifiers, invalid literal text, and
 unsupported shapes for variables referenced by the template.
 
+`RuntimeException` is thrown when the PCRE engine fails while processing a
+template, for example when an extremely long variable name exhausts a PCRE
+resource limit. This indicates an environment limit, not invalid input; the
+threshold depends on the PCRE build and `pcre.jit` configuration.
+
 Exceptions thrown by a value object's `__toString()` method propagate unchanged;
 they are not converted to `InvalidArgumentException`.
 

--- a/src/UriTemplate.php
+++ b/src/UriTemplate.php
@@ -353,8 +353,17 @@ final class UriTemplate
 
         $matches = [];
         $pattern = '/\A('.self::VARNAME_PATTERN.')(?::([1-9][0-9]{0,3})|(\*))?\z/';
+        $result = \preg_match($pattern, $varspec, $matches);
 
-        if (\preg_match($pattern, $varspec, $matches) !== 1) {
+        if ($result === false) {
+            // A PCRE engine failure, such as an exhausted JIT stack or
+            // backtrack limit on a very long variable name, is not a template
+            // syntax error; spec section 2.3 places no length limit on
+            // variable names.
+            throw new \RuntimeException(\sprintf('Unable to parse variable specifier: %s', \preg_last_error_msg()));
+        }
+
+        if ($result !== 1) {
             throw self::invalidExpression($expression, \sprintf('invalid variable specifier "%s"', $varspec));
         }
 

--- a/tests/UriTemplateTest.php
+++ b/tests/UriTemplateTest.php
@@ -302,6 +302,7 @@ final class UriTemplateTest extends TestCase
             'dot separator' => ['{last.name}', ['last.name' => 'Doe'], 'Doe'],
             'pct encoded space in name' => ['{/Some%20Thing}', ['Some%20Thing' => 'foo'], '/foo'],
             'pct encoded unicode in name' => ['{?Stra%C3%9Fe}', ['Stra%C3%9Fe' => 'Gruner Weg'], '?Stra%C3%9Fe=Gruner%20Weg'],
+            'long name' => ['{'.\str_repeat('a', 512).'}', [\str_repeat('a', 512) => 'value'], 'value'],
         ];
     }
 
@@ -353,6 +354,20 @@ final class UriTemplateTest extends TestCase
     public function testRejectsInvalidVariableNames(string $template): void
     {
         $this->assertInvalidTemplate($template);
+    }
+
+    public function testReportsEngineFailuresOnLongVariableNamesAsRuntimeException(): void
+    {
+        // Spec section 2.3 places no length limit on variable names, so a
+        // grammar-valid long name must either expand or surface a PCRE
+        // engine failure as a RuntimeException, never as invalid syntax.
+        $name = \str_repeat('a', 20000);
+
+        try {
+            self::assertSame('ok', UriTemplate::expand('{'.$name.'}', [$name => 'ok']));
+        } catch (\RuntimeException $e) {
+            self::assertStringContainsString('Unable to parse variable specifier', $e->getMessage());
+        }
     }
 
     /**


### PR DESCRIPTION
preg_match() returns int(0) when the subject does not match and bool(false) when the PCRE engine itself fails, and parseVarSpec() treated both as invalid syntax. RFC 6570 section 2.3 places no length limit on variable names, so a grammar-valid name of twenty thousand characters is currently rejected as an invalid variable specifier under the default pcre.jit=1, while the identical template expands successfully with pcre.jit=0, meaning accept and reject behavior varies with the PCRE runtime configuration and an environment resource limit is misreported as a template syntax error. Engine failures now throw `RuntimeException` carrying `preg_last_error_msg()`, matching the existing engine failure handling in `expand()` and `encodeValue()`, and `expand()` has always declared `@throws \RuntimeException`. Grammar non-matches keep the unchanged `InvalidArgumentException`.