### PR TITLE
Stop splitting pct-encoded code points in prefixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 - Fixed map keys not using the operator's allow set under reserved and fragment expansion
 - Fixed all-null lists and maps throwing with prefix modifiers instead of being skipped as undefined
 - Fixed PCRE engine failures on very long variable names being reported as invalid template syntax
+- Fixed prefix modifiers splitting Unicode code points encoded as multiple pct-encoded triplets
 
 ### Removed
 - Dropped support for PHP 7.2 and 7.3

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -209,9 +209,10 @@ UriTemplate::expand('/search{?q}', ['q' => 'default']);
 Prefix modifiers, such as `{var:3}`, are valid only for scalar or stringable
 values. Prefix lengths must be positive integers from `1` through `9999`, with
 no leading zeroes. Prefix lengths are counted as Unicode code points and
-existing pct-encoded triplets, not bytes or visual grapheme clusters. A prefixed
-string value must be valid UTF-8, otherwise expansion throws
-`InvalidArgumentException`.
+existing pct-encoded characters, not bytes or visual grapheme clusters.
+Consecutive pct-encoded triplets that encode one Unicode code point in UTF-8,
+such as `%C3%A9`, count as one character. A prefixed string value must be valid
+UTF-8, otherwise expansion throws `InvalidArgumentException`.
 
 Before:
 

--- a/docs/input-contract.md
+++ b/docs/input-contract.md
@@ -75,10 +75,12 @@ invalid.
 Prefix modifiers are not valid on composite values such as lists or maps, and a
 varspec cannot combine prefix and explode modifiers.
 
-Prefix length counts Unicode characters and existing percent-encoded triplets,
-not bytes. For example, `%2F` counts as one character before the selected prefix
-is encoded for the expression type. Values must be valid UTF-8, as described in
-[values](#values).
+Prefix length counts Unicode characters and existing percent-encoded
+characters, not bytes. For example, `%2F` counts as one character before the
+selected prefix is encoded for the expression type, and consecutive
+percent-encoded triplets that encode one Unicode code point in UTF-8, such as
+`%C3%A9`, also count as one character. Values must be valid UTF-8, as described
+in [values](#values).
 
 ## Nested Query Arrays
 

--- a/docs/uri-template-usage.md
+++ b/docs/uri-template-usage.md
@@ -178,10 +178,14 @@ UriTemplate::expand('{+id}', ['id' => 'admin%2F']);
 
 ## Specification Conformance Notes
 
-Prefix modifiers count existing percent-encoded triplets as one character. RFC
-6570 section 3.2.1 defines a prefix as the "first max-length characters of the
-decoded value" and forbids splitting a multi-octet or percent-encoded sequence.
-For example, `{id:1}` with the value `admin%2F` selects `a`. Several other
+Prefix modifiers count existing percent-encoded characters as one character.
+RFC 6570 section 3.2.1 defines a prefix as the "first max-length characters of
+the decoded value" and forbids splitting a multi-octet or percent-encoded
+sequence, so a run of consecutive percent-encoded triplets that encodes one
+Unicode code point in UTF-8 also counts as one character. For example, `{id:1}`
+with the value `admin%2F` selects `a`, and `{+id:1}` with the value
+`%C3%A9clair` selects `%C3%A9`. Triplets that do not encode a single code
+point, such as a lone lead octet, count as one character each. Several other
 implementations count raw characters instead and can split percent-encoded
 triplets, so prefixed expansions of values containing triplets can differ
 between libraries.

--- a/src/UriTemplate.php
+++ b/src/UriTemplate.php
@@ -605,7 +605,68 @@ final class UriTemplate
             throw self::invalidVariable($expression, $name, 'prefix modifier requires valid UTF-8');
         }
 
-        return \implode('', \array_slice($matches[0], 0, $length));
+        $tokens = $matches[0];
+        $count = \count($tokens);
+        $prefix = '';
+        $index = 0;
+
+        // Spec sections 2.4.1 and 3.2.1: prefix lengths count each Unicode
+        // code point as one character so that the value is never split in
+        // mid-character, so consecutive pct-encoded triplets that encode a
+        // single UTF-8 code point are kept together as one character.
+        for ($taken = 0; $taken < $length && $index < $count; ++$taken) {
+            $width = 1;
+
+            if (\strlen($tokens[$index]) === 3 && $tokens[$index][0] === '%') {
+                $width = self::pctEncodedCodePointTripletCount($tokens, $index);
+            }
+
+            while ($width-- > 0) {
+                $prefix .= $tokens[$index];
+                ++$index;
+            }
+        }
+
+        return $prefix;
+    }
+
+    /**
+     * Count the consecutive pct-encoded triplets starting at the index that
+     * together encode a single Unicode code point as UTF-8.
+     *
+     * Returns 1 when the triplet does not begin such a sequence, so triplets
+     * that do not participate in a multi-octet-encoded character keep
+     * counting as one character each.
+     *
+     * @param list<string> $tokens
+     */
+    private static function pctEncodedCodePointTripletCount(array $tokens, int $index): int
+    {
+        $lead = (int) \hexdec(\substr($tokens[$index], 1));
+
+        if ($lead >= 0xC2 && $lead <= 0xDF) {
+            $octets = 2;
+        } elseif ($lead >= 0xE0 && $lead <= 0xEF) {
+            $octets = 3;
+        } elseif ($lead >= 0xF0 && $lead <= 0xF4) {
+            $octets = 4;
+        } else {
+            return 1;
+        }
+
+        $decoded = \chr($lead);
+
+        for ($offset = 1; $offset < $octets; ++$offset) {
+            $token = $tokens[$index + $offset] ?? '';
+
+            if (\strlen($token) !== 3 || $token[0] !== '%') {
+                return 1;
+            }
+
+            $decoded .= \chr((int) \hexdec(\substr($token, 1)));
+        }
+
+        return \preg_match('/\A.\z/us', $decoded) === 1 ? $octets : 1;
     }
 
     private static function encodeLiteralSegment(string $literal, int $baseOffset): string

--- a/tests/UriTemplateTest.php
+++ b/tests/UriTemplateTest.php
@@ -405,6 +405,17 @@ final class UriTemplateTest extends TestCase
             'query unicode character' => ['{?var:1}', ['var' => "\xC3\xA9clair"], '?var=%C3%A9'],
             'pct triplet counts as one character' => ['{var:1}', ['var' => '%2Fabc'], '%252F'],
             'reserved pct triplet counts as one character' => ['{+var:1}', ['var' => '%2Fabc'], '%2F'],
+            'simple pct code point counts as one character' => ['{var:1}', ['var' => '%C3%A9llo'], '%25C3%25A9'],
+            'simple pct code point and ascii character' => ['{var:2}', ['var' => '%C3%A9llo'], '%25C3%25A9l'],
+            'reserved pct code point counts as one character' => ['{+var:1}', ['var' => '%C3%A9llo'], '%C3%A9'],
+            'reserved lowercase pct code point' => ['{+var:1}', ['var' => '%c3%a9llo'], '%c3%a9'],
+            'reserved three triplet pct code point' => ['{+var:1}', ['var' => '%E2%82%ACx'], '%E2%82%AC'],
+            'reserved four triplet pct code point' => ['{+var:1}', ['var' => '%F0%9F%92%A9rest'], '%F0%9F%92%A9'],
+            'reserved four triplet pct code point and ascii characters' => ['{+var:3}', ['var' => '%F0%9F%92%A9rest'], '%F0%9F%92%A9re'],
+            'fragment pct code point counts as one character' => ['{#var:1}', ['var' => '%C3%A9llo'], '#%C3%A9'],
+            'query pct code point counts as one character' => ['{?var:1}', ['var' => '%C3%A9llo'], '?var=%25C3%25A9'],
+            'lone lead triplet counts as one character' => ['{+var:2}', ['var' => '%C3xyz'], '%C3x'],
+            'overlong pct sequence counts per triplet' => ['{+var:1}', ['var' => '%E0%80%80'], '%E0'],
         ];
     }
 


### PR DESCRIPTION
The prefix modifier counts an existing pct-encoded triplet as one character, but when a single Unicode code point is encoded as multiple consecutive triplets the count was applied per triplet, so `{+x:1}` with `%C3%A9llo` expanded to `%C3`, a lone UTF-8 lead octet that decodes to no code point and is invalid UTF-8, which we require of values everywhere else. RFC 6570 section 2.4.1 says the numbering is in characters rather than octets precisely to avoid splitting between the octets of a multi-octet-encoded character, and section 3.2.1 says to count each Unicode code point as one character, which is also the justification our own conformance notes cite for the counting rule. `prefixValue()` now groups consecutive triplets that decode to exactly one valid UTF-8 code point and counts the group as one character, so `{+x:1}` with `%C3%A9llo` expands to `%C3%A9`. Triplets that do not form such a sequence, including lone lead octets, overlong encodings, and surrogates, keep counting one each, so all single-triplet and degenerate-sequence outputs are unchanged, as is the encoding stage. The docs now state the grouping rule explicitly, and the interop caveat about raw-character implementations remains accurate.