### PR TITLE
Improve invalid UTF-8 error diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 - Fixed PCRE engine failures on very long variable names being reported as invalid template syntax
 - Fixed prefix modifiers splitting Unicode code points encoded as multiple pct-encoded triplets
 - Fixed path-style expansion of composites rendering bare `name` instead of `name=` for empty joined members
+- Fixed invalid UTF-8 errors for list and map members not reporting the member path
+- Fixed exception messages embedding raw invalid UTF-8 bytes from map keys
+- Fixed nested query array members set to `null` being rejected for their keys instead of being omitted
 
 ### Removed
 - Dropped support for PHP 7.2 and 7.3

--- a/docs/input-contract.md
+++ b/docs/input-contract.md
@@ -93,8 +93,9 @@ exploded query or query-continuation expression, such as `{?filter*}` or
 
 Nested query arrays must have scalar leaves. Recursive arrays, arrays nested too
 deeply, and nested objects are rejected. Nested `null` values are treated as
-undefined members and omitted. Stringable objects are accepted as direct map
-values, but not as leaves inside nested query arrays.
+undefined members and omitted. Omission happens before member validation, so
+the keys of omitted `null` members are not validated. Stringable objects are
+accepted as direct map values, but not as leaves inside nested query arrays.
 
 Nested query arrays use RFC 3986 query encoding with PHP bracket syntax:
 
@@ -124,6 +125,11 @@ For example, use `/search%20terms/{id}` instead of `/search terms/{id}`.
 `InvalidArgumentException` is thrown for invalid template syntax, unsupported
 operators, invalid variable names, invalid modifiers, invalid literal text, and
 unsupported shapes for variables referenced by the template.
+
+Errors for invalid list and map members identify the member by path, such as
+`x[1]` or `filter[author][name]`. Exception messages are always valid UTF-8:
+when a member path contains invalid byte sequences, bytes outside printable
+ASCII are escaped as `\xHH`.
 
 `RuntimeException` is thrown when the PCRE engine fails while processing a
 template, for example when an extremely long variable name exhausts a PCRE

--- a/src/UriTemplate.php
+++ b/src/UriTemplate.php
@@ -178,20 +178,22 @@ final class UriTemplate
                         continue;
                     }
 
+                    $memberPath = \sprintf('%s[%s]', $value['value'], (string) $key);
+
                     if ($isAssoc) {
                         $rawKey = (string) $key;
                         // Spec section 3.2.1: pair names are encoded in the
                         // same way as simple string values, so reserved
                         // expansion and fragment expansion keep reserved
                         // characters and pct-encoded triplets in names.
-                        $key = self::encodeValue($rawKey, $allowReserved, $matches[1], $value['value']);
+                        $key = self::encodeValue($rawKey, $allowReserved, $matches[1], $memberPath);
                         $isNestedArray = \is_array($var);
                     } else {
                         $isNestedArray = false;
                     }
 
                     if (!$isNestedArray) {
-                        $var = self::encodeValue(self::stringifyValue($var), $allowReserved, $matches[1], $value['value']);
+                        $var = self::encodeValue(self::stringifyValue($var), $allowReserved, $matches[1], $memberPath);
                     }
 
                     if ($value['modifier'] === '*') {
@@ -436,10 +438,35 @@ final class UriTemplate
     {
         return new \InvalidArgumentException(\sprintf(
             'Invalid URI template variable "%s" in "{%s}": %s.',
-            $path,
+            self::sanitizeVariablePath($path),
             $expression,
             $message
         ));
+    }
+
+    /**
+     * Make a variable member path safe to embed in an exception message.
+     *
+     * Member paths are built from raw array keys, so a path can contain
+     * byte sequences that are not valid UTF-8. Escaping such bytes keeps
+     * the exception message itself valid UTF-8 for consumers that
+     * serialize messages, such as json_encode-based loggers.
+     */
+    private static function sanitizeVariablePath(string $path): string
+    {
+        if (\preg_match('//u', $path) === 1) {
+            return $path;
+        }
+
+        $sanitized = '';
+
+        for ($offset = 0, $length = \strlen($path); $offset < $length; ++$offset) {
+            $ord = \ord($path[$offset]);
+
+            $sanitized .= $ord >= 0x20 && $ord <= 0x7E ? $path[$offset] : \sprintf('\x%02X', $ord);
+        }
+
+        return $sanitized;
     }
 
     /**
@@ -556,14 +583,18 @@ final class UriTemplate
         }
 
         foreach ($value as $key => $member) {
+            if ($member === null) {
+                // Spec sections 2.3 and 2.4.2: only members with defined
+                // values are present in the expansion, so null members are
+                // omitted before their keys are validated, matching the
+                // handling of null members in top-level maps.
+                continue;
+            }
+
             $memberPath = \sprintf('%s[%s]', $path, (string) $key);
 
             if (\is_string($key) && \preg_match('//u', $key) !== 1) {
                 throw self::invalidVariable($expression, $memberPath, 'variable values must be valid UTF-8');
-            }
-
-            if ($member === null) {
-                continue;
             }
 
             if (\is_scalar($member)) {

--- a/tests/UriTemplateTest.php
+++ b/tests/UriTemplateTest.php
@@ -442,6 +442,49 @@ final class UriTemplateTest extends TestCase
     }
 
     /**
+     * @return array<string,array{0:string, 1:array<string,mixed>, 2:string}>
+     */
+    public static function invalidUtf8MemberPathProvider(): array
+    {
+        return [
+            'list member' => ['{x}', ['x' => ['ok', "\xC3\x28"]], 'x[1]'],
+            'map value' => ['{?x*}', ['x' => ['a' => "\xC3\x28"]], 'x[a]'],
+            'map key' => ['{?x*}', ['x' => ["\xC3\x28" => 'v']], 'x[\xC3(]'],
+            'nested value' => ['{?x*}', ['x' => ['k' => ['n' => "\xC3\x28"]]], 'x[k][n]'],
+            'nested key' => ['{?x*}', ['x' => ['k' => ["\xC3\x28" => 'v']]], 'x[k][\xC3(]'],
+        ];
+    }
+
+    /**
+     * @dataProvider invalidUtf8MemberPathProvider
+     *
+     * @param array<string,mixed> $variables
+     */
+    public function testReportsMemberPathsForInvalidUtf8(string $template, array $variables, string $path): void
+    {
+        try {
+            UriTemplate::expand($template, $variables);
+            self::fail('Expected InvalidArgumentException was not thrown.');
+        } catch (\InvalidArgumentException $e) {
+            self::assertStringContainsString(\sprintf('variable "%s"', $path), $e->getMessage());
+            // Exception messages must stay valid UTF-8 for consumers that
+            // serialize them, such as json_encode-based loggers.
+            self::assertSame(1, \preg_match('//u', $e->getMessage()));
+        }
+    }
+
+    public function testEscapesInvalidUtf8KeysInShapeErrorMessages(): void
+    {
+        try {
+            UriTemplate::expand('{?x*}', ['x' => ["\xC3\x28" => new \stdClass()]]);
+            self::fail('Expected InvalidArgumentException was not thrown.');
+        } catch (\InvalidArgumentException $e) {
+            self::assertStringContainsString('variable "x[\xC3(]"', $e->getMessage());
+            self::assertSame(1, \preg_match('//u', $e->getMessage()));
+        }
+    }
+
+    /**
      * @return array<string,array{0:string}>
      */
     public static function invalidModifierProvider(): array
@@ -553,6 +596,9 @@ final class UriTemplateTest extends TestCase
             'all null map members undefined' => ['X{.x}', ['x' => ['a' => null]], 'X'],
             'all null list members undefined' => ['{#x}', ['x' => [null]], ''],
             'null nested query leaf skipped' => ['{?x*}', ['x' => ['a' => ['b' => null, 'c' => 'v']]], '?a%5Bc%5D=v'],
+            'null member with invalid utf-8 key skipped' => ['{?x*}', ['x' => ["\xC3\x28" => null, 'kept' => 'v']], '?kept=v'],
+            'nested null member with invalid utf-8 key skipped' => ['{?x*}', ['x' => ['k' => ["\xC3\x28" => null], 'kept' => 'v']], '?kept=v'],
+            'all nested members null with invalid utf-8 key undefined' => ['{?x*}', ['x' => ['k' => ["\xC3\x28" => null]]], ''],
             'valid multibyte value' => ['{x}', ['x' => "caf\xC3\xA9 \xF0\x9F\x98\x80"], 'caf%C3%A9%20%F0%9F%98%80'],
             'false in query' => ['{?x}', ['x' => false], '?x=0'],
             'bools in list' => ['{x}', ['x' => [true, false]], '1,0'],


### PR DESCRIPTION
Invalid UTF-8 in a list or map member is reported with the bare variable path, while shape errors report `x[1]` and nested query errors report `x[k][n]`, so the caller cannot tell which member is bad. Map keys containing invalid bytes were also interpolated verbatim into exception messages, making `getMessage()` itself invalid UTF-8, which breaks `json_encode` based loggers and PSR-3 formatters. Finally, a nested query array member set to null was rejected for its invalid UTF-8 key even though the input contract says nested null values are treated as undefined members and omitted, and the identical shape at the top level is already silently skipped. Member values and keys now report paths like `x[1]` and `x[a]`, `invalidVariable()` escapes bytes outside printable ASCII as `\xHH` whenever a path is not valid UTF-8 so messages stay serializable while valid multibyte paths pass through unchanged, and `assertNestedQueryShape()` skips null members before validating their keys, matching the documented contract and the depth-zero behavior. No conformant expansion output changes, and invalid keys with defined values still throw, so no invalid bytes can reach expansion output.