### PR TITLE
Expand floats independently of the process locale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 - Fixed invalid UTF-8 errors for list and map members not reporting the member path
 - Fixed exception messages embedding raw invalid UTF-8 bytes from map keys
 - Fixed nested query array members set to `null` being rejected for their keys instead of being omitted
+- Fixed float values expanding with the locale decimal separator on PHP versions before 8.0
 
 ### Removed
 - Dropped support for PHP 7.2 and 7.3

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -251,6 +251,11 @@ expands as `0`, at every nesting level. Guzzle URI Template 1.x expanded
 top-level `false` as an empty string; pass `''` explicitly if that output is
 required, or `null` to omit the variable.
 
+Floats always expand with `.` as the decimal separator. Guzzle URI Template 1.x
+followed the `LC_NUMERIC` locale on PHP versions before 8.0, so a process that
+had called `setlocale()` with a comma-decimal locale such as `de_DE` could
+expand `3.5` as `3%2C5`.
+
 ```php
 UriTemplate::expand('/search{?q,page}', [
     'q' => null,

--- a/docs/input-contract.md
+++ b/docs/input-contract.md
@@ -37,6 +37,17 @@ Supported variable values are:
 
 Booleans expand as `1` and `0` at every nesting level.
 
+Floats expand using PHP's float-to-string conversion with the decimal separator
+normalized to `.`, so output does not depend on the process locale, including on
+PHP 7.4 where the plain cast honors `LC_NUMERIC`. The conversion rounds to the
+`precision` ini setting (`14` by default), so `0.1 + 0.2` expands as `0.3`, and
+uses scientific notation, such as `1.0E+20`, when fixed notation would need more
+significant digits than `precision` allows or the magnitude is below `0.0001`.
+The `+` in an exponent is percent-encoded as `%2B` except under reserved and
+fragment expansion. Non-finite floats expand as the literal strings `INF`,
+`-INF`, and `NAN`. Format floats yourself, for example with `number_format()`
+or `sprintf()`, when a specific decimal representation is required.
+
 An empty string is a defined value and is expanded. An empty array is treated as
 undefined and omitted. Missing variables and variables set to `null` are treated
 as undefined and omitted.

--- a/docs/uri-template-usage.md
+++ b/docs/uri-template-usage.md
@@ -199,6 +199,12 @@ these conditions as errors instead of producing diagnostic output.
 Booleans expand as `1` and `0` at every nesting level, as described in the
 [input contract](input-contract.md#values).
 
+Floats are converted to strings by the library because RFC 6570 defines only
+string, list, and associative-array values. The conversion always uses `.` as
+the decimal separator, regardless of the process locale, and follows PHP's
+`precision` setting, as described in the [input
+contract](input-contract.md#values).
+
 Variable values must be valid UTF-8, per RFC 6570 section 1.6. Invalid byte
 sequences throw `InvalidArgumentException`, as described in the [input
 contract](input-contract.md#values).

--- a/src/UriTemplate.php
+++ b/src/UriTemplate.php
@@ -200,7 +200,10 @@ final class UriTemplate
                         if ($isAssoc) {
                             if ($isNestedArray) {
                                 // Nested arrays must allow for deeply nested structures.
-                                $var = \http_build_query([$rawKey => $var], '', '&', \PHP_QUERY_RFC3986);
+                                // Float members are stringified first because
+                                // http_build_query's own float conversion
+                                // honors LC_NUMERIC before PHP 8.0.
+                                $var = \http_build_query([$rawKey => self::stringifyNestedFloats($var)], '', '&', \PHP_QUERY_RFC3986);
                                 if ($var === '') {
                                     continue;
                                 }
@@ -281,6 +284,10 @@ final class UriTemplate
      * from the empty string and matches the http_build_query semantics used
      * by the nested query-array extension.
      *
+     * Floats are formatted with "." as the decimal separator regardless of
+     * the process locale, because the plain float-to-string cast honors
+     * LC_NUMERIC before PHP 8.0.
+     *
      * @param mixed $value
      */
     private static function stringifyValue($value): string
@@ -289,7 +296,54 @@ final class UriTemplate
             return $value ? '1' : '0';
         }
 
+        if (\is_float($value)) {
+            return self::stringifyFloat($value);
+        }
+
         return (string) $value;
+    }
+
+    /**
+     * Convert a float to its expansion string independently of the locale.
+     *
+     * Before PHP 8.0 the float-to-string cast honors LC_NUMERIC, so a
+     * comma-decimal locale such as de_DE renders 3.5 as "3,5". Normalizing
+     * the locale decimal separator back to "." keeps expansion output
+     * deterministic across runtimes while preserving the precision-dependent
+     * formatting of the cast.
+     */
+    private static function stringifyFloat(float $value): string
+    {
+        $string = (string) $value;
+        $decimalPoint = \localeconv()['decimal_point'] ?? '.';
+
+        if ('.' !== $decimalPoint && '' !== $decimalPoint) {
+            $string = \str_replace($decimalPoint, '.', $string);
+        }
+
+        return $string;
+    }
+
+    /**
+     * Stringify float members of a nested query array so http_build_query
+     * does not apply its own locale-sensitive float conversion on PHP 7.4.
+     *
+     * @param array<array-key,mixed> $value
+     *
+     * @return array<array-key,mixed>
+     */
+    private static function stringifyNestedFloats(array $value): array
+    {
+        /** @var mixed $member */
+        foreach ($value as $key => $member) {
+            if (\is_float($member)) {
+                $value[$key] = self::stringifyFloat($member);
+            } elseif (\is_array($member)) {
+                $value[$key] = self::stringifyNestedFloats($member);
+            }
+        }
+
+        return $value;
     }
 
     /**

--- a/tests/UriTemplateTest.php
+++ b/tests/UriTemplateTest.php
@@ -618,6 +618,75 @@ final class UriTemplateTest extends TestCase
     }
 
     /**
+     * @return array<string,array{0:string, 1:array<string,mixed>, 2:string}>
+     */
+    public static function floatValueProvider(): array
+    {
+        return [
+            'fixed notation' => ['{x}', ['x' => 3.5], '3.5'],
+            'negative fixed notation' => ['{x}', ['x' => -2.25], '-2.25'],
+            'scientific notation plus encoded' => ['{x}', ['x' => 1.0E+20], '1.0E%2B20'],
+            'scientific notation plus reserved' => ['{+x}', ['x' => 1.0E+20], '1.0E+20'],
+            'scientific notation plus fragment' => ['{#x}', ['x' => 1.0E+20], '#1.0E+20'],
+            'scientific notation plus query' => ['{?x}', ['x' => 1.0E+20], '?x=1.0E%2B20'],
+            'float in list' => ['{x}', ['x' => [1.5, 2.5]], '1.5,2.5'],
+            'float in exploded map' => ['{?x*}', ['x' => ['a' => 3.5]], '?a=3.5'],
+            'float in nested query map' => ['{?x*}', ['x' => ['a' => ['b' => 3.5]]], '?a%5Bb%5D=3.5'],
+            'float prefix' => ['{x:3}', ['x' => 37.5], '37.'],
+            'infinity' => ['{x}', ['x' => \INF], 'INF'],
+            'negative infinity' => ['{x}', ['x' => -\INF], '-INF'],
+            'nan' => ['{x}', ['x' => \NAN], 'NAN'],
+        ];
+    }
+
+    /**
+     * @dataProvider floatValueProvider
+     *
+     * @param array<string,mixed> $variables
+     */
+    public function testExpandsFloatValues(string $template, array $variables, string $expansion): void
+    {
+        self::assertSame($expansion, UriTemplate::expand($template, $variables));
+    }
+
+    public function testFloatExpansionFollowsThePrecisionIniSetting(): void
+    {
+        $previous = \ini_get('precision');
+        self::assertNotFalse($previous);
+
+        try {
+            \ini_set('precision', '14');
+            self::assertSame('0.3', UriTemplate::expand('{x}', ['x' => 0.1 + 0.2]));
+            self::assertSame('1.0E-5', UriTemplate::expand('{x}', ['x' => 0.00001]));
+
+            \ini_set('precision', '17');
+            self::assertSame('0.30000000000000004', UriTemplate::expand('{x}', ['x' => 0.1 + 0.2]));
+        } finally {
+            \ini_set('precision', $previous);
+        }
+    }
+
+    public function testFloatExpansionIsLocaleIndependent(): void
+    {
+        $previous = \setlocale(\LC_NUMERIC, '0');
+        self::assertNotFalse($previous);
+
+        if (\setlocale(\LC_NUMERIC, 'de_DE.UTF-8', 'de_DE.utf8', 'de_DE', 'fr_FR.UTF-8', 'fr_FR.utf8', 'fr_FR') === false) {
+            self::markTestSkipped('No comma-decimal locale is available.');
+        }
+
+        try {
+            self::assertSame('3.5', UriTemplate::expand('{x}', ['x' => 3.5]));
+            self::assertSame('?x=3.5', UriTemplate::expand('{?x}', ['x' => 3.5]));
+            self::assertSame('?a=3.5', UriTemplate::expand('{?x*}', ['x' => ['a' => 3.5]]));
+            self::assertSame('?a%5Bb%5D=3.5', UriTemplate::expand('{?x*}', ['x' => ['a' => ['b' => 3.5]]]));
+            self::assertSame('1.0E%2B25', UriTemplate::expand('{x}', ['x' => 1.0E+25]));
+        } finally {
+            \setlocale(\LC_NUMERIC, $previous);
+        }
+    }
+
+    /**
      * @return array<string,array{0:string, 1:array<string,mixed>}>
      */
     public static function invalidVariableShapeProvider(): array


### PR DESCRIPTION
On PHP 7.4, which composer.json still supports, the plain float-to-string cast and the internal float conversion of http_build_query() honor LC_NUMERIC, so a process that has called setlocale() with a comma-decimal locale such as de_DE expands `['x' => 3.5]` as `3%2C5` instead of `3.5`, silently producing a different URI than PHP 8.0 and later for identical input. RFC 6570 section 3 requires each variable's value to be formed prior to expansion, and since the library performs the float-to-string formation itself, that formation should be a deterministic function of the template and variables. stringifyValue() now routes floats through a helper that performs the same cast and normalizes the locale decimal separator back to `.`, which is a structural no-op on PHP 8.0 and later, and float members of nested query arrays are stringified before http_build_query() so the documented nested-array extension is equally deterministic. The cast's precision-dependent formatting is preserved, and the previously undocumented float-to-string consequences, including scientific notation, the per-operator encoding of the exponent's `+`, and INF and NAN expanding as literal text, are now described in the input contract.