### PR TITLE
Reject non-finite float values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 - Nested null values in lists and maps are now treated as undefined members and omitted
 - Variable values must now be valid UTF-8 and invalid byte sequences throw `InvalidArgumentException`
 - Booleans now expand as `1` and `0` at every nesting level
+- Non-finite floats now throw `InvalidArgumentException` instead of expanding as `INF` or `NAN`
 
 ### Fixed
 - Fixed invalid template expressions being accepted as parameter names in query and path-style expansions

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -72,8 +72,8 @@ UriTemplate::expand('{name:3}', ['name' => 'value']);
 ```
 
 Validate variable maps before expansion if they contain user-provided values.
-Unsupported resources, closures, non-stringable objects, and unsupported nested
-arrays now throw `InvalidArgumentException`.
+Unsupported resources, closures, non-stringable objects, non-finite floats, and
+unsupported nested arrays now throw `InvalidArgumentException`.
 
 Apply defaults before expansion instead of using non-RFC template extension
 syntax:
@@ -254,7 +254,9 @@ required, or `null` to omit the variable.
 Floats always expand with `.` as the decimal separator. Guzzle URI Template 1.x
 followed the `LC_NUMERIC` locale on PHP versions before 8.0, so a process that
 had called `setlocale()` with a comma-decimal locale such as `de_DE` could
-expand `3.5` as `3%2C5`.
+expand `3.5` as `3%2C5`. Non-finite floats are not supported: `INF`, `-INF`,
+and `NAN` now throw `InvalidArgumentException` instead of expanding as literal
+text.
 
 ```php
 UriTemplate::expand('/search{?q,page}', [

--- a/docs/input-contract.md
+++ b/docs/input-contract.md
@@ -44,9 +44,10 @@ PHP 7.4 where the plain cast honors `LC_NUMERIC`. The conversion rounds to the
 uses scientific notation, such as `1.0E+20`, when fixed notation would need more
 significant digits than `precision` allows or the magnitude is below `0.0001`.
 The `+` in an exponent is percent-encoded as `%2B` except under reserved and
-fragment expansion. Non-finite floats expand as the literal strings `INF`,
-`-INF`, and `NAN`. Format floats yourself, for example with `number_format()`
-or `sprintf()`, when a specific decimal representation is required.
+fragment expansion. Non-finite floats are not supported: `INF`, `-INF`, and
+`NAN` throw `InvalidArgumentException`. Format floats yourself, for example
+with `number_format()` or `sprintf()`, when a specific decimal representation
+is required.
 
 An empty string is a defined value and is expanded. An empty array is treated as
 undefined and omitted. Missing variables and variables set to `null` are treated
@@ -64,9 +65,9 @@ expand as lists. All other arrays, including reordered, sparse, and mixed-key
 arrays, expand as maps. Map and list order follows PHP array insertion order.
 
 Unsupported values include resources, closures, non-stringable objects,
-recursive arrays, arrays nested too deeply, and nested arrays outside exploded
-query-style expansions. Unsupported values are validated only when the template
-references that variable.
+non-finite floats, recursive arrays, arrays nested too deeply, and nested
+arrays outside exploded query-style expansions. Unsupported values are
+validated only when the template references that variable.
 
 Variable values must be valid UTF-8. Invalid byte sequences throw
 `InvalidArgumentException`. Encode binary data, for example with base64, before

--- a/docs/uri-template-usage.md
+++ b/docs/uri-template-usage.md
@@ -202,8 +202,8 @@ Booleans expand as `1` and `0` at every nesting level, as described in the
 Floats are converted to strings by the library because RFC 6570 defines only
 string, list, and associative-array values. The conversion always uses `.` as
 the decimal separator, regardless of the process locale, and follows PHP's
-`precision` setting, as described in the [input
-contract](input-contract.md#values).
+`precision` setting. Non-finite floats are rejected, as described in the
+[input contract](input-contract.md#values).
 
 Variable values must be valid UTF-8, per RFC 6570 section 1.6. Invalid byte
 sequences throw `InvalidArgumentException`, as described in the [input

--- a/src/UriTemplate.php
+++ b/src/UriTemplate.php
@@ -530,6 +530,10 @@ final class UriTemplate
     private static function assertVariableShape(array $varspec, $variable, string $expression, string $operator): void
     {
         if (self::isScalarLike($variable)) {
+            if (\is_float($variable) && !\is_finite($variable)) {
+                throw self::invalidVariable($expression, $varspec['value'], 'non-finite floats are not supported');
+            }
+
             return;
         }
 
@@ -582,6 +586,10 @@ final class UriTemplate
             $memberPath = \sprintf('%s[%d]', $path, $index);
 
             if ($member === null || self::isScalarLike($member)) {
+                if (\is_float($member) && !\is_finite($member)) {
+                    throw self::invalidVariable($expression, $memberPath, 'non-finite floats are not supported');
+                }
+
                 continue;
             }
 
@@ -611,6 +619,10 @@ final class UriTemplate
             $memberPath = \sprintf('%s[%s]', $path, (string) $key);
 
             if ($member === null || self::isScalarLike($member)) {
+                if (\is_float($member) && !\is_finite($member)) {
+                    throw self::invalidVariable($expression, $memberPath, 'non-finite floats are not supported');
+                }
+
                 continue;
             }
 
@@ -654,6 +666,10 @@ final class UriTemplate
             if (\is_scalar($member)) {
                 if (\is_string($member) && \preg_match('//u', $member) !== 1) {
                     throw self::invalidVariable($expression, $memberPath, 'variable values must be valid UTF-8');
+                }
+
+                if (\is_float($member) && !\is_finite($member)) {
+                    throw self::invalidVariable($expression, $memberPath, 'non-finite floats are not supported');
                 }
 
                 continue;

--- a/tests/UriTemplateTest.php
+++ b/tests/UriTemplateTest.php
@@ -633,9 +633,6 @@ final class UriTemplateTest extends TestCase
             'float in exploded map' => ['{?x*}', ['x' => ['a' => 3.5]], '?a=3.5'],
             'float in nested query map' => ['{?x*}', ['x' => ['a' => ['b' => 3.5]]], '?a%5Bb%5D=3.5'],
             'float prefix' => ['{x:3}', ['x' => 37.5], '37.'],
-            'infinity' => ['{x}', ['x' => \INF], 'INF'],
-            'negative infinity' => ['{x}', ['x' => -\INF], '-INF'],
-            'nan' => ['{x}', ['x' => \NAN], 'NAN'],
         ];
     }
 
@@ -710,6 +707,12 @@ final class UriTemplateTest extends TestCase
             'invalid utf-8 map key' => ['{?x*}', ['x' => ["\xC3" => 'v']]],
             'invalid utf-8 nested value' => ['{?x*}', ['x' => ['a' => ['b' => "\xC3"]]]],
             'invalid utf-8 nested key' => ['{?x*}', ['x' => ['a' => ["\xC3" => 'v']]]],
+            'nan scalar' => ['{x}', ['x' => \NAN]],
+            'infinity scalar' => ['{x}', ['x' => \INF]],
+            'negative infinity scalar' => ['{x}', ['x' => -\INF]],
+            'nan in list' => ['{x}', ['x' => [\NAN]]],
+            'infinity in map' => ['{?x*}', ['x' => ['a' => \INF]]],
+            'nan in nested query map' => ['{?x*}', ['x' => ['a' => ['b' => \NAN]]]],
         ];
     }
 


### PR DESCRIPTION
PHP 8.5 warns when NAN is coerced to string, and expansion can hit that coercion for top-level scalars, list and map members, and nested query leaves. Rather than special-case NAN, this rejects all non-finite floats with InvalidArgumentException: INF, -INF, and NAN are meaningless as URI data, and json_encode refuses them for the same reason, so rejecting only NAN would leave an odd contract. The checks sit in the shape assertions next to the existing UTF-8 validation, which means the errors carry member paths like x[a][b] and nothing non-finite can ever reach the cast or http_build_query(). Finite floats are unaffected, and the docs now list non-finite floats alongside the other unsupported values.