### PR TITLE
Stringify non-finite floats explicitly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 
 ### Fixed
 - Fixed the operator's leading character being omitted when defined variables expand to empty strings
+- Fixed non-finite float values emitting coercion warnings on PHP 8.5
 
 ## v1.0.6 - 2026-05-23
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -9,7 +9,7 @@ parameters:
 		-
 			message: '#^Cannot cast mixed to string\.$#'
 			identifier: cast.string
-			count: 3
+			count: 1
 			path: src/UriTemplate.php
 
 		-

--- a/src/UriTemplate.php
+++ b/src/UriTemplate.php
@@ -103,14 +103,14 @@ final class UriTemplate
                     }
 
                     if (!$isNestedArray) {
-                        $var = self::encodeValue((string) $var, $allowReserved);
+                        $var = self::encodeValue(self::stringifyValue($var), $allowReserved);
                     }
 
                     if ($value['modifier'] === '*') {
                         if ($isAssoc) {
                             if ($isNestedArray) {
                                 // Nested arrays must allow for deeply nested structures.
-                                $var = \http_build_query([$rawKey => $var], '', '&', \PHP_QUERY_RFC3986);
+                                $var = \http_build_query([$rawKey => self::stringifyNonFiniteFloats($var)], '', '&', \PHP_QUERY_RFC3986);
                                 if ($var === '') {
                                     continue;
                                 }
@@ -148,10 +148,12 @@ final class UriTemplate
                     $expanded = \implode(',', $kvp);
                 }
             } else {
+                $variable = self::stringifyValue($variable);
+
                 if ($value['modifier'] === ':' && isset($value['position'])) {
-                    $variable = \substr((string) $variable, 0, $value['position']);
+                    $variable = \substr($variable, 0, $value['position']);
                 }
-                $expanded = self::encodeValue((string) $variable, $allowReserved);
+                $expanded = self::encodeValue($variable, $allowReserved);
             }
 
             if ($actuallyUseQuery) {
@@ -230,6 +232,45 @@ final class UriTemplate
     private static function isAssoc(array $array): bool
     {
         return $array && \array_keys($array)[0] !== 0;
+    }
+
+    /**
+     * Cast a variable value to its expansion string.
+     *
+     * Non-finite floats are converted explicitly because coercing them to
+     * string triggers a warning on PHP 8.5.
+     *
+     * @param mixed $value
+     */
+    private static function stringifyValue($value): string
+    {
+        if (\is_float($value) && !\is_finite($value)) {
+            return \is_nan($value) ? 'NAN' : ($value > 0 ? 'INF' : '-INF');
+        }
+
+        return (string) $value;
+    }
+
+    /**
+     * Stringify non-finite float members of a nested array so that
+     * http_build_query does not trigger coercion warnings on PHP 8.5.
+     *
+     * @param array<array-key,mixed> $value
+     *
+     * @return array<array-key,mixed>
+     */
+    private static function stringifyNonFiniteFloats(array $value): array
+    {
+        /** @var mixed $member */
+        foreach ($value as $key => $member) {
+            if (\is_float($member) && !\is_finite($member)) {
+                $value[$key] = self::stringifyValue($member);
+            } elseif (\is_array($member)) {
+                $value[$key] = self::stringifyNonFiniteFloats($member);
+            }
+        }
+
+        return $value;
     }
 
     private static function encodeValue(string $value, bool $allowReserved): string

--- a/tests/UriTemplateTest.php
+++ b/tests/UriTemplateTest.php
@@ -136,6 +136,27 @@ final class UriTemplateTest extends TestCase
         self::assertSame($expansion, UriTemplate::expand($template, $variables));
     }
 
+    public static function nonFiniteFloatProvider(): array
+    {
+        return [
+            'nan' => ['{x}', ['x' => \NAN], 'NAN'],
+            'infinity' => ['{x}', ['x' => \INF], 'INF'],
+            'negative infinity' => ['{x}', ['x' => -\INF], '-INF'],
+            'nan prefix' => ['{x:2}', ['x' => \NAN], 'NA'],
+            'nan in list' => ['{x}', ['x' => [\NAN, 'v']], 'NAN,v'],
+            'infinity in exploded map' => ['{?x*}', ['x' => ['a' => \INF]], '?a=INF'],
+            'nan in nested query map' => ['{?x*}', ['x' => ['a' => ['b' => \NAN]]], '?a%5Bb%5D=NAN'],
+        ];
+    }
+
+    /**
+     * @dataProvider nonFiniteFloatProvider
+     */
+    public function testExpandsNonFiniteFloats(string $template, array $variables, string $expansion): void
+    {
+        self::assertSame($expansion, UriTemplate::expand($template, $variables));
+    }
+
     public static function reservedExpansionPctTripletProvider(): array
     {
         return [


### PR DESCRIPTION
PHP 8.5 warns when NAN is coerced to string, and 1.0 coerces variable values in four places: scalar values, prefix-modified values, list and map members, and nested arrays passed to http_build_query(). Anyone expanding NAN on 8.5 now gets warnings in their logs, or exceptions if their error handler promotes them. This converts non-finite floats explicitly before any coercion happens, producing the same strings as before, so it is purely a warning fix with no behavior change. The 2.0 branch instead rejects non-finite floats as part of its strict input contract.