### PR TITLE
Document remaining conformance decisions

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -278,7 +278,10 @@ Nested arrays in maps are supported for exploded query-style expansions, such as
 `{?var*}` and `{&var*}`, to preserve existing Guzzle URI Template behavior.
 
 `null` members inside lists and maps are treated as undefined and omitted,
-consistent with top-level `null` and RFC 6570 section 2.4.2.
+consistent with top-level `null`. RFC 6570 section 3.2.1 expands a list as a
+concatenation of "the defined member string values", and section 2.4.2 states
+that "only the defined pairs are present in the expansion". A list or map whose
+members are all `null` is treated as a wholly undefined variable.
 
 Unsupported values throw `InvalidArgumentException` before expansion. This
 includes resources, closures, non-stringable objects, unsupported nested arrays,

--- a/docs/input-contract.md
+++ b/docs/input-contract.md
@@ -58,7 +58,9 @@ omitted, like top-level `null`. A list or map whose members are all `null` is
 treated as undefined and omitted, like an empty array. A list or map with at
 least one defined member is a defined, non-empty value: in named non-exploded
 expansions, `=` follows the name even when every member expands to the empty
-string, so `{;l}` with `['l' => ['']]` expands to `;l=`.
+string, so `{;l}` with `['l' => ['']]` expands to `;l=`. See the [conformance
+notes](uri-template-usage.md#specification-conformance-notes) for how the
+all-`null` rule maps to RFC 6570.
 
 Arrays whose keys are exactly `0` through `n-1` in ascending insertion order
 expand as lists. All other arrays, including reordered, sparse, and mixed-key
@@ -72,6 +74,14 @@ validated only when the template references that variable.
 Variable values must be valid UTF-8. Invalid byte sequences throw
 `InvalidArgumentException`. Encode binary data, for example with base64, before
 expansion.
+
+Values are expanded as given, without Unicode normalization. Canonically
+equivalent inputs expand to different URIs: the decomposed value `"e\u{0301}"`
+expands to `e%CC%81`, while the precomposed value `"\u{00E9}"` expands to
+`%C3%A9`. Normalize user-entered text, for example with ext-intl's
+`Normalizer::normalize($value, Normalizer::FORM_C)`, before expansion. See the
+[conformance notes](uri-template-usage.md#specification-conformance-notes) for
+the RFC 6570 section 1.6 background.
 
 ## Prefix Modifiers
 
@@ -94,8 +104,12 @@ Prefix length counts Unicode characters and existing percent-encoded
 characters, not bytes. For example, `%2F` counts as one character before the
 selected prefix is encoded for the expression type, and consecutive
 percent-encoded triplets that encode one Unicode code point in UTF-8, such as
-`%C3%A9`, also count as one character. Values must be valid UTF-8, as described
-in [values](#values).
+`%C3%A9`, also count as one character. A combining mark is its own character,
+so a prefix can split a decomposed character sequence: `{x:1}` with the
+decomposed value `"e\u{0301}f"` selects only `e`, dropping the combining
+accent. Normalize values to NFC before expansion to keep user-perceived
+characters intact. Values must be valid UTF-8, as described in
+[values](#values).
 
 ## Nested Query Arrays
 
@@ -126,8 +140,16 @@ UriTemplate::expand('/search{?filter*}', [
 Empty nested arrays are omitted from exploded query expansions. Empty scalar
 values are preserved.
 
-Empty-string keys in nested query arrays produce PHP append syntax
-(`a%5B%5D=v`), which does not round-trip the key.
+Empty-string keys at nested levels of a nested query array produce PHP append
+syntax (`a%5B%5D=v`), which does not round-trip the key.
+
+A top-level empty-string key whose value is a non-empty nested array produces
+bracket syntax with an empty root name (`%5Ba%5D=v`, decoded `[a]=v`), which
+drops the root pair name and does not round-trip. Deeper nesting keeps the
+empty root name (`%5Ba%5D%5Bb%5D=v`). This applies to `{?var*}` and `{&var*}`
+alike. A top-level empty-string key with a scalar value keeps the empty pair
+name in the output (`=v`), and one with an empty nested array is omitted, like
+other empty nested arrays.
 
 ## Validation Errors
 

--- a/docs/uri-template-usage.md
+++ b/docs/uri-template-usage.md
@@ -160,7 +160,9 @@ UriTemplate::expand('/search{?filter*}', [
 
 Empty nested arrays are omitted from exploded query expansions. `null` members
 inside lists and maps are treated as undefined members and omitted, like
-top-level `null`.
+top-level `null`. A list or map whose members are all `null` is treated as
+undefined, as described in the [specification conformance
+notes](#specification-conformance-notes).
 
 Variable values are encoded during expansion according to the expression type.
 Existing percent-encoded triplets in reserved and fragment expansions are
@@ -217,6 +219,39 @@ emptiness before its members are joined, so `{;l}` expanded with
 test the comma-joined member string instead and omit the `=`, so path-style
 expansions of composite values whose members all expand empty can differ
 between libraries.
+
+Exploded map members with empty-string values render as `name=` under the
+simple, reserved (`+`), fragment (`#`), label (`.`), and path segment (`/`)
+operators. RFC 6570 contradicts itself for these operators: the normative
+prose in section 3.2.1 appends each exploded pair as "name=value" or, "if the
+value is the empty string and the expression type does not indicate form-style
+parameters", simply "name", while the non-normative appendix A algorithm
+appends every pair with a defined value as "name=value", and no erratum
+resolves the conflict. This library follows the appendix A rendering, matching
+other implementations. The named operators agree under both readings, with `;`
+following the section 3.2.1 prose via its ifemp rule, so `{;x*}` with an
+empty-string member produces a bare name.
+
+A list or map whose members are all `null` is treated as a wholly undefined
+variable, so it is omitted together with the operator's first character unless
+another variable in the expression is defined. RFC 6570 section 2.3 states
+this rule only for associative arrays, which are "considered undefined if the
+array contains zero members or if all member names in the array are associated
+with undefined values"; a list is called undefined only "if the list contains
+zero members". This library maps `null` members to undefined members, and
+skipping every undefined member leaves a list with zero members, so the same
+rule applies to lists.
+
+No Unicode normalization is applied to templates or variable values. RFC 6570
+section 1.6 states that a value provided by a user "SHOULD be normalized as
+Normalization Form C" (NFC) prior to expansion, while a server-provided value
+can be assumed to already be in the form the server expects. This library
+cannot know where a value came from, so normalization is left to the caller,
+and canonically equivalent inputs expand to different URIs: the decomposed
+value `"e\u{0301}"` expands to `e%CC%81`, while the precomposed value
+`"\u{00E9}"` expands to `%C3%A9`. Normalize user-entered text, for example
+with ext-intl's `Normalizer::normalize($value, Normalizer::FORM_C)`, before
+expansion.
 
 ## Related
 

--- a/src/UriTemplate.php
+++ b/src/UriTemplate.php
@@ -173,8 +173,10 @@ final class UriTemplate
                 /** @var mixed $var */
                 foreach ($variable as $key => $var) {
                     if ($var === null) {
-                        // Spec sections 2.3 and 2.4.2: only members with
-                        // defined values are present in the expansion.
+                        // Spec section 3.2.1: a list expands "the defined
+                        // member string values", and spec section 2.4.2:
+                        // "only the defined pairs are present in the
+                        // expansion", so undefined members are skipped.
                         continue;
                     }
 
@@ -227,6 +229,12 @@ final class UriTemplate
                 }
 
                 if ($kvp === []) {
+                    // A composite with no defined members is treated as an
+                    // undefined variable. Spec section 2.3 states this for
+                    // associative arrays only; extending it to lists whose
+                    // members are all null is a documented conformance
+                    // decision, since the spec calls a list undefined only
+                    // when it contains zero members.
                     continue;
                 } elseif ($value['modifier'] === '*') {
                     $expanded = \implode($joiner, $kvp);

--- a/tests/UriTemplateTest.php
+++ b/tests/UriTemplateTest.php
@@ -137,7 +137,12 @@ final class UriTemplateTest extends TestCase
             ['{&mixed_list*}',      '&mixed_list=red&mixed_list='],
             ['{;kv_empty*}',        ';a;b=x'],
             ['{?kv_empty*}',        '?a=&b=x'],
+            ['{&kv_empty*}',        '&a=&b=x'],
+            ['{kv_empty*}',         'a=,b=x'],
+            ['{+kv_empty*}',        'a=,b=x'],
+            ['{#kv_empty*}',        '#a=,b=x'],
             ['X{.kv_empty*}',       'X.a=.b=x'],
+            ['{/kv_empty*}',        '/a=/b=x'],
             ['{+reserved_keys}',    'a/b,c/d,x%20y,v'],
             ['{+reserved_keys*}',   'a/b=c/d,x%20y=v'],
             ['{#reserved_keys}',    '#a/b,c/d,x%20y,v'],
@@ -436,6 +441,32 @@ final class UriTemplateTest extends TestCase
         self::assertSame($expansion, UriTemplate::expand($template, $variables));
     }
 
+    /**
+     * @return array<string,array{0:string, 1:array<string,mixed>, 2:string}>
+     */
+    public static function unicodeNormalizationProvider(): array
+    {
+        return [
+            // RFC 6570 section 1.6 leaves NFC normalization of user-provided
+            // values to the caller, so canonically equivalent inputs differ.
+            'nfd value passes through' => ['{var}', ['var' => "e\xCC\x81"], 'e%CC%81'],
+            'nfc value passes through' => ['{var}', ['var' => "\xC3\xA9"], '%C3%A9'],
+            'nfd literal passes through' => ["e\xCC\x81/{var}", ['var' => 'v'], 'e%CC%81/v'],
+            'prefix splits decomposed sequence' => ['{var:1}', ['var' => "e\xCC\x81f"], 'e'],
+            'nfd map member passes through' => ['{?x*}', ['x' => ['k' => "e\xCC\x81"]], '?k=e%CC%81'],
+        ];
+    }
+
+    /**
+     * @dataProvider unicodeNormalizationProvider
+     *
+     * @param array<string,mixed> $variables
+     */
+    public function testDoesNotNormalizeUnicode(string $template, array $variables, string $expansion): void
+    {
+        self::assertSame($expansion, UriTemplate::expand($template, $variables));
+    }
+
     public function testRejectsInvalidUtf8PrefixValues(): void
     {
         $this->assertInvalidTemplate('{var:1}', ['var' => "\xC3"]);
@@ -557,6 +588,12 @@ final class UriTemplateTest extends TestCase
             'query prefix on all null map' => ['{?x:2}', ['x' => ['a' => null]], ''],
             'label prefix on all null map' => ['X{.x:1}', ['x' => ['a' => null]], 'X'],
             'remaining variables still expand' => ['{x:1,y}', ['x' => ['a' => null], 'y' => 'v'], 'v'],
+            'all null list path' => ['{/x}', ['x' => [null]], ''],
+            'all null list query' => ['{?x}', ['x' => [null]], ''],
+            'all null list exploded query' => ['{?x*}', ['x' => [null]], ''],
+            'all null list multiple members' => ['{?l}', ['l' => [null, null]], ''],
+            'all null map query' => ['{?m}', ['m' => ['k' => null]], ''],
+            'all null list beside defined variable' => ['{/x,y}', ['x' => [null], 'y' => 'z'], '/z'],
         ];
     }
 
@@ -919,6 +956,55 @@ final class UriTemplateTest extends TestCase
      * @dataProvider emptyNestedQueryArrayProvider
      */
     public function testSkipsEmptyNestedQueryArrays(string $template, array $variables, string $expansion): void
+    {
+        self::assertSame($expansion, UriTemplate::expand($template, $variables));
+    }
+
+    /**
+     * @return array<string,array{0:string, 1:array<string,mixed>, 2:string}>
+     */
+    public static function emptyStringKeyNestedQueryArrayProvider(): array
+    {
+        return [
+            'top-level empty-string key with nested-array value' => [
+                '{?x*}',
+                ['x' => ['' => ['a' => 'v']]],
+                '?%5Ba%5D=v',
+            ],
+            'top-level empty-string key with deeper nesting' => [
+                '{?x*}',
+                ['x' => ['' => ['a' => ['b' => 'v']]]],
+                '?%5Ba%5D%5Bb%5D=v',
+            ],
+            'continuation operator top-level empty-string key' => [
+                '{&x*}',
+                ['x' => ['' => ['a' => 'v']]],
+                '&%5Ba%5D=v',
+            ],
+            'top-level empty-string key with scalar value' => [
+                '{?x*}',
+                ['x' => ['' => 'v']],
+                '?=v',
+            ],
+            'top-level empty-string key with empty nested array' => [
+                '{?x*}',
+                ['x' => ['' => []]],
+                '',
+            ],
+            'nested empty-string key append syntax' => [
+                '{?x*}',
+                ['x' => ['a' => ['' => 'v']]],
+                '?a%5B%5D=v',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider emptyStringKeyNestedQueryArrayProvider
+     *
+     * @param array<string,mixed> $variables
+     */
+    public function testExpandsEmptyStringKeysInNestedQueryArrays(string $template, array $variables, string $expansion): void
     {
         self::assertSame($expansion, UriTemplate::expand($template, $variables));
     }


### PR DESCRIPTION
This completes the specification conformance notes with the decisions that were not yet written down, and pins each one with characterization tests. Exploded map members with empty-string values render as name= under the unnamed operators, following the non-normative appendix A algorithm; the normative prose in section 3.2.1 says bare name for everything except the form-style operators, the RFC contradicts itself, and no erratum resolves it, so the choice deserves a note. A list or map whose members are all null is treated as wholly undefined, which extends a rule section 2.3 states only for associative arrays, so the conformance notes now say so and the inline comments and UPGRADING.md cite the right sections for list members. No NFC normalization is applied, since the section 1.6 SHOULD is conditioned on value provenance that a library cannot know; the docs now explain that canonically equivalent inputs expand to different URIs, that a prefix modifier can split a decomposed character sequence, and that callers can normalize with ext-intl before expansion. Finally, the nested query-array extension drops the root pair name when a top-level empty-string key holds a nested array, which was only documented for nested levels. No runtime behavior changes; the source edits are comments only.