### PR TITLE
Escape invalid UTF-8 bytes in expression diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 - Fixed exception messages embedding raw invalid UTF-8 bytes from map keys
 - Fixed nested query array members set to `null` being rejected for their keys instead of being omitted
 - Fixed float values expanding with the locale decimal separator on PHP versions before 8.0
+- Fixed exception messages embedding raw invalid UTF-8 bytes from expression text
 
 ### Removed
 - Dropped support for PHP 7.2 and 7.3

--- a/docs/input-contract.md
+++ b/docs/input-contract.md
@@ -162,8 +162,8 @@ unsupported shapes for variables referenced by the template.
 
 Errors for invalid list and map members identify the member by path, such as
 `x[1]` or `filter[author][name]`. Exception messages are always valid UTF-8:
-when a member path contains invalid byte sequences, bytes outside printable
-ASCII are escaped as `\xHH`.
+when a member path or expression text contains invalid byte sequences, bytes
+outside printable ASCII are escaped as `\xHH`.
 
 `RuntimeException` is thrown when the PCRE engine fails while processing a
 template, for example when an extremely long variable name exhausts a PCRE

--- a/src/UriTemplate.php
+++ b/src/UriTemplate.php
@@ -459,8 +459,8 @@ final class UriTemplate
     {
         return new \InvalidArgumentException(\sprintf(
             'Invalid URI template expression "{%s}": %s.',
-            $expression,
-            $message
+            self::sanitizeDiagnosticText($expression),
+            self::sanitizeDiagnosticText($message)
         ));
     }
 
@@ -500,32 +500,33 @@ final class UriTemplate
     {
         return new \InvalidArgumentException(\sprintf(
             'Invalid URI template variable "%s" in "{%s}": %s.',
-            self::sanitizeVariablePath($path),
-            $expression,
-            $message
+            self::sanitizeDiagnosticText($path),
+            self::sanitizeDiagnosticText($expression),
+            self::sanitizeDiagnosticText($message)
         ));
     }
 
     /**
-     * Make a variable member path safe to embed in an exception message.
+     * Make diagnostic text safe to embed in an exception message.
      *
-     * Member paths are built from raw array keys, so a path can contain
-     * byte sequences that are not valid UTF-8. Escaping such bytes keeps
-     * the exception message itself valid UTF-8 for consumers that
-     * serialize messages, such as json_encode-based loggers.
+     * Expression text comes from raw template bytes and member paths are
+     * built from raw array keys, so either can contain byte sequences that
+     * are not valid UTF-8. Escaping such bytes keeps the exception message
+     * itself valid UTF-8 for consumers that serialize messages, such as
+     * json_encode-based loggers.
      */
-    private static function sanitizeVariablePath(string $path): string
+    private static function sanitizeDiagnosticText(string $value): string
     {
-        if (\preg_match('//u', $path) === 1) {
-            return $path;
+        if (\preg_match('//u', $value) === 1) {
+            return $value;
         }
 
         $sanitized = '';
 
-        for ($offset = 0, $length = \strlen($path); $offset < $length; ++$offset) {
-            $ord = \ord($path[$offset]);
+        for ($offset = 0, $length = \strlen($value); $offset < $length; ++$offset) {
+            $ord = \ord($value[$offset]);
 
-            $sanitized .= $ord >= 0x20 && $ord <= 0x7E ? $path[$offset] : \sprintf('\x%02X', $ord);
+            $sanitized .= $ord >= 0x20 && $ord <= 0x7E ? $value[$offset] : \sprintf('\x%02X', $ord);
         }
 
         return $sanitized;

--- a/tests/UriTemplateTest.php
+++ b/tests/UriTemplateTest.php
@@ -518,6 +518,34 @@ final class UriTemplateTest extends TestCase
     /**
      * @return array<string,array{0:string}>
      */
+    public static function invalidUtf8ExpressionProvider(): array
+    {
+        return [
+            'lone invalid byte' => ["{\xC3}"],
+            'invalid byte after name' => ["{bad\xC3}"],
+            'invalid byte after literal text' => ["/ok/{bad\xC3}"],
+            'invalid byte in variable list' => ["{?x,\xC3}"],
+            'invalid byte before whitespace' => ["{bad\xC3 }"],
+        ];
+    }
+
+    /**
+     * @dataProvider invalidUtf8ExpressionProvider
+     */
+    public function testEscapesInvalidUtf8ExpressionsInErrorMessages(string $template): void
+    {
+        try {
+            UriTemplate::expand($template, []);
+            self::fail('Expected InvalidArgumentException was not thrown.');
+        } catch (\InvalidArgumentException $e) {
+            self::assertStringContainsString('\xC3', $e->getMessage());
+            self::assertSame(1, \preg_match('//u', $e->getMessage()));
+        }
+    }
+
+    /**
+     * @return array<string,array{0:string}>
+     */
     public static function invalidModifierProvider(): array
     {
         return [


### PR DESCRIPTION
Invalid UTF-8 inside an expression currently flows straight into the exception message, because parseVarSpec() interpolates the raw expression and varspec. Expanding `"{bad\xC3}"` therefore throws an InvalidArgumentException whose message is itself invalid UTF-8, which breaks consumers that serialize messages, such as json_encode-based loggers, and contradicts the input contract's promise that exception messages are always valid UTF-8.

This generalizes the member path sanitizer from #80 into sanitizeDiagnosticText() and applies it to every interpolated part of both exception factories, so expression text is escaped the same way as member paths. Sanitizing the message argument also covers get_debug_type() output, since PHP class names may legally contain bytes that are not valid UTF-8. Expansion behavior is unchanged.