### PR TITLE
Add tests for stringable leaves in nested query arrays

### DIFF
--- a/tests/UriTemplateTest.php
+++ b/tests/UriTemplateTest.php
@@ -766,6 +766,7 @@ final class UriTemplateTest extends TestCase
             'nested array in unexploded map' => ['{?x}', ['x' => ['a' => ['b' => 'c']]]],
             'nested array in non-query exploded map' => ['{/x*}', ['x' => ['a' => ['b' => 'c']]]],
             'nested object in query extension' => ['{?x*}', ['x' => ['a' => ['b' => new \stdClass()]]]],
+            'nested stringable object in query extension' => ['{?x*}', ['x' => ['a' => ['b' => new StringableValue('ok')]]]],
             'invalid utf-8 scalar' => ['{x}', ['x' => "\xC3"]],
             'invalid utf-8 reserved scalar' => ['{+x}', ['x' => "\xC3"]],
             'invalid utf-8 list member' => ['{x}', ['x' => ['ok', "\xC3"]]],
@@ -789,6 +790,17 @@ final class UriTemplateTest extends TestCase
     public function testRejectsInvalidVariableShapes(string $template, array $variables): void
     {
         $this->assertInvalidTemplate($template, $variables);
+    }
+
+    public function testRejectsStringableLeavesInNestedQueryArrays(): void
+    {
+        try {
+            UriTemplate::expand('{?x*}', ['x' => ['a' => ['b' => new StringableValue('ok')]]]);
+            self::fail('Expected InvalidArgumentException was not thrown.');
+        } catch (\InvalidArgumentException $e) {
+            self::assertStringContainsString('variable "x[a][b]"', $e->getMessage());
+            self::assertStringContainsString('expected scalar or nested array', $e->getMessage());
+        }
     }
 
     public function testIgnoresUnusedInvalidVariableShapes(): void


### PR DESCRIPTION
The input contract documents that stringable objects are accepted as direct map values but not as leaves inside nested query arrays, and assertNestedQueryShape() enforces this by checking is_scalar() rather than isScalarLike(). That distinction was not covered by any test, so a refactor that switched the nested validation over to isScalarLike() would silently start accepting stringable leaves and change the documented contract.

This adds an invalid shape provider case alongside the existing nested object case, plus a dedicated test pinning the x[a][b] member path and the rejection message. There are no implementation changes.