### PR TITLE
Report exact offsets for invalid UTF-8 in literal text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 - Fixed nested query array members set to `null` being rejected for their keys instead of being omitted
 - Fixed float values expanding with the locale decimal separator on PHP versions before 8.0
 - Fixed exception messages embedding raw invalid UTF-8 bytes from expression text
+- Fixed invalid UTF-8 in literal text reporting the offset of the literal segment instead of the first invalid byte
+- Fixed PCRE engine failures during literal text validation being reported as invalid UTF-8
 
 ### Removed
 

--- a/src/UriTemplate.php
+++ b/src/UriTemplate.php
@@ -798,7 +798,16 @@ final class UriTemplate
         $result = \preg_match_all('/%[0-9A-Fa-f]{2}|./us', $literal, $matches, \PREG_OFFSET_CAPTURE);
 
         if ($result === false || \preg_last_error() !== \PREG_NO_ERROR) {
-            throw self::invalidTemplate($baseOffset, 'literal text must be valid UTF-8');
+            if (\preg_last_error() === \PREG_BAD_UTF8_ERROR) {
+                throw self::invalidTemplate(
+                    $baseOffset + self::validUtf8PrefixLength($literal),
+                    'literal text must be valid UTF-8'
+                );
+            }
+
+            // A PCRE engine failure, such as an exhausted resource limit, is
+            // not a template syntax error.
+            throw new \RuntimeException(\sprintf('Unable to process template: %s', \preg_last_error_msg()));
         }
 
         $encoded = '';
@@ -844,6 +853,25 @@ final class UriTemplate
         }
 
         return $encoded;
+    }
+
+    /**
+     * Count the bytes of the longest well-formed UTF-8 prefix.
+     *
+     * Mirrors the UTF8-char grammar of RFC 3629 section 4 byte by byte so
+     * the reported template offset identifies the first invalid byte rather
+     * than the start of the enclosing literal segment.
+     */
+    private static function validUtf8PrefixLength(string $value): int
+    {
+        $matches = [];
+        $result = \preg_match(
+            '/\A(?:[\x00-\x7F]|[\xC2-\xDF][\x80-\xBF]|\xE0[\xA0-\xBF][\x80-\xBF]|[\xE1-\xEC][\x80-\xBF]{2}|\xED[\x80-\x9F][\x80-\xBF]|[\xEE-\xEF][\x80-\xBF]{2}|\xF0[\x90-\xBF][\x80-\xBF]{2}|[\xF1-\xF3][\x80-\xBF]{3}|\xF4[\x80-\x8F][\x80-\xBF]{2})*+/',
+            $value,
+            $matches
+        );
+
+        return $result === 1 ? \strlen($matches[0]) : 0;
     }
 
     private static function isAllowedAsciiLiteral(string $char): bool

--- a/tests/UriTemplateTest.php
+++ b/tests/UriTemplateTest.php
@@ -227,6 +227,37 @@ final class UriTemplateTest extends TestCase
     }
 
     /**
+     * @return array<string,array{0:string, 1:int}>
+     */
+    public static function invalidUtf8LiteralOffsetProvider(): array
+    {
+        return [
+            'leading invalid byte' => ["\xC3foo", 0],
+            'invalid byte after ascii' => ["foo\xC3bar", 3],
+            'invalid byte after multibyte literal' => ["caf\xC3\xA9\xC3", 5],
+            'overlong encoding' => ["foo\xC0\xAFbar", 3],
+            'truncated multibyte at end' => ["abc\xE2\x82", 3],
+            'invalid byte after expression' => ["/{id}/bad\xC3", 9],
+        ];
+    }
+
+    /**
+     * @dataProvider invalidUtf8LiteralOffsetProvider
+     */
+    public function testReportsExactOffsetsForInvalidUtf8Literals(string $template, int $offset): void
+    {
+        try {
+            UriTemplate::expand($template, ['id' => 'a']);
+            self::fail('Expected InvalidArgumentException was not thrown.');
+        } catch (\InvalidArgumentException $e) {
+            self::assertSame(
+                \sprintf('Invalid URI template at offset %d: literal text must be valid UTF-8.', $offset),
+                $e->getMessage()
+            );
+        }
+    }
+
+    /**
      * @return array<string,array{0:string, 1:array<string,mixed>, 2:string}>
      */
     public static function reservedExpansionPctTripletProvider(): array


### PR DESCRIPTION
Invalid UTF-8 in literal text is currently reported at the start of the enclosing literal segment, because tokenization fails before any per-character offsets are known, so expanding `"foo\xC3bar"` reports offset 0 rather than 3. Every other literal error already reports the exact byte, and RFC 6570 section 3 says the location of the error should be indicated.

This adds validUtf8PrefixLength(), which measures the longest well-formed prefix using the UTF8-char grammar from RFC 3629 section 4, so the reported offset now identifies the first invalid byte. The failure branch also no longer conflates engine failures with bad input: anything other than PREG_BAD_UTF8_ERROR is now reported as a RuntimeException, consistent with how PCRE failures are handled when parsing variable specifiers.