### PR TITLE
Refine diagnostic escaping

### DIFF
--- a/docs/input-contract.md
+++ b/docs/input-contract.md
@@ -161,9 +161,8 @@ operators, invalid variable names, invalid modifiers, invalid literal text, and
 unsupported shapes for variables referenced by the template.
 
 Errors for invalid list and map members identify the member by path, such as
-`x[1]` or `filter[author][name]`. Exception messages are always valid UTF-8:
-when a member path or expression text contains invalid byte sequences, bytes
-outside printable ASCII are escaped as `\xHH`.
+`x[1]` or `filter[author][name]`. When a member path or expression text contains
+invalid byte sequences, bytes outside printable ASCII are escaped as `\xHH`.
 
 `RuntimeException` is thrown when the PCRE engine fails while processing a
 template, for example when an extremely long variable name exhausts a PCRE

--- a/src/UriTemplate.php
+++ b/src/UriTemplate.php
@@ -459,8 +459,8 @@ final class UriTemplate
     {
         return new \InvalidArgumentException(\sprintf(
             'Invalid URI template expression "{%s}": %s.',
-            self::sanitizeDiagnosticText($expression),
-            self::sanitizeDiagnosticText($message)
+            self::escapeInvalidUtf8ForMessage($expression),
+            self::escapeInvalidUtf8ForMessage($message)
         ));
     }
 
@@ -500,22 +500,16 @@ final class UriTemplate
     {
         return new \InvalidArgumentException(\sprintf(
             'Invalid URI template variable "%s" in "{%s}": %s.',
-            self::sanitizeDiagnosticText($path),
-            self::sanitizeDiagnosticText($expression),
-            self::sanitizeDiagnosticText($message)
+            self::escapeInvalidUtf8ForMessage($path),
+            self::escapeInvalidUtf8ForMessage($expression),
+            $message
         ));
     }
 
     /**
-     * Make diagnostic text safe to embed in an exception message.
-     *
-     * Expression text comes from raw template bytes and member paths are
-     * built from raw array keys, so either can contain byte sequences that
-     * are not valid UTF-8. Escaping such bytes keeps the exception message
-     * itself valid UTF-8 for consumers that serialize messages, such as
-     * json_encode-based loggers.
+     * Escape invalid UTF-8 text before embedding it in an exception message.
      */
-    private static function sanitizeDiagnosticText(string $value): string
+    private static function escapeInvalidUtf8ForMessage(string $value): string
     {
         if (\preg_match('//u', $value) === 1) {
             return $value;


### PR DESCRIPTION
This keeps invalid UTF-8 escaping on raw expression text and member paths while leaving internal variable error messages untouched. It also shortens the helper comment and narrows the input contract wording.