### PR TITLE
Freeze trim characters ahead of PHP 8.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to `uri-template` will be documented in this file.
 
 Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) principles.
 
+## v1.0.9 - Unreleased
+
+### Changed
+
+- Pass explicit trim characters ahead of the PHP 8.6 trim default change
+
 ## v1.0.8 - 2026-06-23
 
 ### Fixed

--- a/src/UriTemplate.php
+++ b/src/UriTemplate.php
@@ -202,7 +202,7 @@ final class UriTemplate
 
         $result['values'] = [];
         foreach (\explode(',', $expression) as $value) {
-            $value = \trim($value);
+            $value = \trim($value, " \n\r\t\0\x0B");
             $varspec = [];
             if ($colonPos = \strpos($value, ':')) {
                 $varspec['value'] = (string) \substr($value, 0, $colonPos);


### PR DESCRIPTION
PHP 8.6 adds the form feed character to the default `$characters` set of `trim`, so the lenient variable specifier trim in the expression parser, the one call in this package relying on the default, would start accepting form-feed-padded specifiers there. This change passes the pre-8.6 set explicitly, keeping the 1.x lenient parse identical on every PHP version. This is the uri-template counterpart of guzzle/guzzle#3775.
