### PR TITLE
Use the real whitespace set for variable specifier errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 - Variable values must now be valid UTF-8 and invalid byte sequences throw `InvalidArgumentException`
 - Booleans now expand as `1` and `0` at every nesting level
 - Non-finite floats now throw `InvalidArgumentException` instead of expanding as `INF` or `NAN`
+- Variable specifier whitespace padding is now detected with the real whitespace set, including form feed
 
 ### Fixed
 

--- a/src/UriTemplate.php
+++ b/src/UriTemplate.php
@@ -416,7 +416,7 @@ final class UriTemplate
      */
     private static function parseVarSpec(string $expression, string $varspec): array
     {
-        if ($varspec !== \trim($varspec)) {
+        if ($varspec !== \trim($varspec, " \t\n\r\v\f")) {
             throw self::invalidExpression($expression, \sprintf('invalid whitespace in variable specifier "%s"', $varspec));
         }
 

--- a/tests/UriTemplateTest.php
+++ b/tests/UriTemplateTest.php
@@ -322,6 +322,7 @@ final class UriTemplateTest extends TestCase
             'empty varspec after comma' => ['{var,}'],
             'empty varspec between commas' => ['{var,,hello}'],
             'whitespace after comma' => ['/resolution{?x, y}'],
+            'form feed after comma' => ["/resolution{?x,\fy}"],
         ];
     }
 


### PR DESCRIPTION
This is the 2.0 counterpart of the 1.0 trim explicitness change. The whitespace check that selects the "invalid whitespace in variable specifier" error message now uses the real whitespace set, space, horizontal tab, line feed, carriage return, vertical tab, and form feed. The PHP default set the check previously relied on wrongly included the null byte, which is not whitespace and now gets the generic invalid-specifier message, and missed form feed, which is. Both paths already threw `InvalidArgumentException`, so only the message selection changes, and the trim no longer depends on the PHP 8.6 default change. A form-feed case is added to the invalid-template provider.
