### PR TITLE
Escape ASCII control bytes in exception diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 - Fixed invalid UTF-8 in literal text reporting the offset of the literal segment instead of the first invalid byte
 - Fixed PCRE engine failures during literal text validation being reported as invalid UTF-8
 - Report PCRE engine failures during variable UTF-8 validation as runtime errors
+- Fixed exception messages embedding raw ASCII control bytes from expression text and map keys
 
 ### Removed
 

--- a/docs/input-contract.md
+++ b/docs/input-contract.md
@@ -161,8 +161,9 @@ operators, invalid variable names, invalid modifiers, invalid literal text, and
 unsupported shapes for variables referenced by the template.
 
 Errors for invalid list and map members identify the member by path, such as
-`x[1]` or `filter[author][name]`. When a member path or expression text contains
-invalid byte sequences, bytes outside printable ASCII are escaped as `\xHH`.
+`x[1]` or `filter[author][name]`. In member paths and expression text, ASCII
+control bytes are escaped as `\xHH`; when the text contains invalid byte
+sequences, all bytes outside printable ASCII are escaped.
 
 `RuntimeException` is thrown when the PCRE engine fails while processing a
 template, for example when an extremely long variable name exhausts a PCRE

--- a/src/UriTemplate.php
+++ b/src/UriTemplate.php
@@ -507,20 +507,21 @@ final class UriTemplate
     }
 
     /**
-     * Escape invalid UTF-8 text before embedding it in an exception message.
+     * Escape unsafe diagnostic text before embedding it in an exception message.
+     *
+     * ASCII control bytes are always escaped as \xHH. Text that is not valid
+     * UTF-8 additionally has all bytes outside printable ASCII escaped.
      */
     private static function escapeInvalidUtf8ForMessage(string $value): string
     {
-        if (\preg_match('//u', $value) === 1) {
-            return $value;
-        }
-
+        $isValidUtf8 = \preg_match('//u', $value) === 1;
         $sanitized = '';
 
         for ($offset = 0, $length = \strlen($value); $offset < $length; ++$offset) {
             $ord = \ord($value[$offset]);
+            $isSafeByte = $ord >= 0x20 && $ord !== 0x7F && ($isValidUtf8 || $ord <= 0x7E);
 
-            $sanitized .= $ord >= 0x20 && $ord <= 0x7E ? $value[$offset] : \sprintf('\x%02X', $ord);
+            $sanitized .= $isSafeByte ? $value[$offset] : \sprintf('\x%02X', $ord);
         }
 
         return $sanitized;

--- a/tests/UriTemplateTest.php
+++ b/tests/UriTemplateTest.php
@@ -576,6 +576,35 @@ final class UriTemplateTest extends TestCase
     }
 
     /**
+     * @return array<string,array{0:string, 1:array<string,mixed>, 2:string, 3:string}>
+     */
+    public static function diagnosticControlByteProvider(): array
+    {
+        return [
+            'nul expression' => ["{bad\x00}", [], '"{bad\x00}"', "\x00"],
+            'esc map key' => ['{?x*}', ['x' => ["red\x1B[31m" => new \stdClass()]], 'variable "x[red\x1B[31m]"', "\x1B"],
+            'del map key' => ['{?x*}', ['x' => ["gone\x7F" => new \stdClass()]], 'variable "x[gone\x7F]"', "\x7F"],
+        ];
+    }
+
+    /**
+     * @dataProvider diagnosticControlByteProvider
+     *
+     * @param array<string,mixed> $variables
+     */
+    public function testEscapesControlBytesInErrorMessages(string $template, array $variables, string $fragment, string $rawByte): void
+    {
+        try {
+            UriTemplate::expand($template, $variables);
+            self::fail('Expected InvalidArgumentException was not thrown.');
+        } catch (\InvalidArgumentException $e) {
+            self::assertStringContainsString($fragment, $e->getMessage());
+            self::assertStringNotContainsString($rawByte, $e->getMessage());
+            self::assertSame(1, \preg_match('//u', $e->getMessage()));
+        }
+    }
+
+    /**
      * @return array<string,array{0:string}>
      */
     public static function invalidModifierProvider(): array


### PR DESCRIPTION
URI Template 2.0 already escapes invalid UTF-8 byte sequences in exception messages, but valid UTF-8 control bytes such as NUL, ESC, and DEL could still reach terminals, logs, and CI output raw through expression text and map-key-derived member paths, including ANSI escape sequences from user-derived map keys. `escapeInvalidUtf8ForMessage()` now always escapes ASCII control bytes as `\xHH` while keeping the existing escaping for invalid byte sequences, so accepted input, rejected input, expansion output, and exception classes are unchanged and only the diagnostic text of inputs that already throw is affected. New tests pin the escaped fragments, the absence of raw control bytes, and the UTF-8 validity of the messages, and the input contract documentation and changelog describe the new escaping.