### PR TITLE
Reject native PHP serialization of UriTemplate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 - Booleans now expand as `1` and `0` at every nesting level
 - Non-finite floats now throw `InvalidArgumentException` instead of expanding as `INF` or `NAN`
 - Variable specifier whitespace padding is now detected with the real whitespace set, including form feed
+- `UriTemplate` now rejects native PHP serialization and unserialization
 
 ### Fixed
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -423,3 +423,9 @@ controls the structure of the expanded URI.
 
 `UriTemplate` now has a private constructor. Use `UriTemplate::expand()`
 statically instead of instantiating the class.
+
+#### Native PHP Serialization
+
+`UriTemplate` no longer supports native PHP `serialize()` or `unserialize()`.
+The class is stateless; call `UriTemplate::expand()` statically instead of
+persisting instances.

--- a/src/UriTemplate.php
+++ b/src/UriTemplate.php
@@ -37,7 +37,23 @@ final class UriTemplate
     }
 
     /**
-     * @param array<string,mixed> $variables Variables to use in the template expansion
+     * @return array<array-key, mixed>
+     */
+    public function __serialize(): array
+    {
+        throw new \LogicException(static::class.' should never be serialized');
+    }
+
+    /**
+     * @param array<array-key, mixed> $data
+     */
+    public function __unserialize(array $data): void
+    {
+        throw new \LogicException(static::class.' should never be unserialized');
+    }
+
+    /**
+     * @param array<string, mixed> $variables Variables to use in the template expansion
      *
      * @throws \InvalidArgumentException When the template syntax or referenced variable shape is invalid
      * @throws \RuntimeException
@@ -69,7 +85,7 @@ final class UriTemplate
     }
 
     /**
-     * @param array<string,mixed> $variables Variables to use in the template expansion
+     * @param array<string, mixed> $variables Variables to use in the template expansion
      *
      * @return \Closure(array{0: string, 1: string}): string
      */
@@ -139,7 +155,7 @@ final class UriTemplate
     /**
      * Process an expansion
      *
-     * @param array<string,mixed>         $variables Variables to use in the template expansion
+     * @param array<string, mixed>        $variables Variables to use in the template expansion
      * @param array{0: string, 1: string} $matches   Matches met in the preg_replace_callback
      *
      * @return string Returns the replacement string
@@ -336,9 +352,9 @@ final class UriTemplate
      * Stringify float members of a nested query array so http_build_query
      * does not apply its own locale-sensitive float conversion on PHP 7.4.
      *
-     * @param array<array-key,mixed> $value
+     * @param array<array-key, mixed> $value
      *
-     * @return array<array-key,mixed>
+     * @return array<array-key, mixed>
      */
     private static function stringifyNestedFloats(array $value): array
     {
@@ -474,7 +490,7 @@ final class UriTemplate
      * Spec section 3.2.1: undefined variables are ignored by the expansion
      * process, so they are skipped before varspec shape validation.
      *
-     * @param array<string,mixed> $variables
+     * @param array<string, mixed> $variables
      */
     private static function isUndefinedVariable(array $variables, string $name): bool
     {
@@ -581,7 +597,7 @@ final class UriTemplate
     }
 
     /**
-     * @param array<array-key,mixed> $value
+     * @param array<array-key, mixed> $value
      */
     private static function assertListShape(string $path, array $value, string $expression): void
     {
@@ -605,7 +621,7 @@ final class UriTemplate
     }
 
     /**
-     * @param array<array-key,mixed> $value
+     * @param array<array-key, mixed> $value
      */
     private static function assertMapShape(
         string $path,
@@ -643,7 +659,7 @@ final class UriTemplate
     }
 
     /**
-     * @param array<array-key,mixed> $value
+     * @param array<array-key, mixed> $value
      */
     private static function assertNestedQueryShape(string $path, array $value, string $expression, int $depth): void
     {
@@ -694,7 +710,7 @@ final class UriTemplate
     /**
      * Determines if an array should be expanded as a map.
      *
-     * @param array<array-key,mixed> $array
+     * @param array<array-key, mixed> $array
      */
     private static function isAssoc(array $array): bool
     {

--- a/tests/UriTemplateTest.php
+++ b/tests/UriTemplateTest.php
@@ -1105,6 +1105,26 @@ final class UriTemplateTest extends TestCase
         self::assertSame('http://example.com/foo/bar/one,two?query=test&more%5B0%5D=fun&more%5B1%5D=ice%20cream&baz%5Bbar%5D=fizz&baz%5Btest%5D=buzz&bam=boo', $result);
     }
 
+    public function testRejectsNativePhpSerialization(): void
+    {
+        $template = (new \ReflectionClass(UriTemplate::class))->newInstanceWithoutConstructor();
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage(UriTemplate::class.' should never be serialized');
+
+        \serialize($template);
+    }
+
+    public function testRejectsNativePhpUnserialization(): void
+    {
+        $class = UriTemplate::class;
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage($class.' should never be unserialized');
+
+        \unserialize(\sprintf('O:%d:"%s":0:{}', \strlen($class), $class));
+    }
+
     /**
      * @return \Generator<int,array{0:string, 1:array<int,string>, 2:array<string,mixed>},mixed,void>
      */


### PR DESCRIPTION
`UriTemplate` has a private constructor in 2.0, but native unserialization bypasses private constructors, so an instance could still be materialized with `unserialize()`. Every other package in the Guzzle family rejects native PHP serialization of runtime objects, so this brings the URI template package in line by throwing a `LogicException` from `__serialize()` and `__unserialize()`. The class is stateless, so this closes a consistency gap rather than a practical gadget risk. New tests pin both refusal directions, the changelog documents the rejection, and the upgrade guide gains a Native PHP Serialization section alongside the instantiation notes. Existing PHPDoc array generics in the touched class are also normalized to use a space after the comma.