### PR TITLE
Generate comma-decimal locale for float CI guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
+      - name: Generate comma-decimal locale
+        run: sudo locale-gen de_DE.UTF-8
+
       - name: Install dependencies
         run: composer update --no-interaction --prefer-stable --prefer-lowest --no-progress
 
@@ -51,6 +54,9 @@ jobs:
 
       - name: Checkout code
         uses: actions/checkout@v6
+
+      - name: Generate comma-decimal locale
+        run: sudo locale-gen de_DE.UTF-8
 
       - name: Install dependencies
         run: composer update --no-interaction --no-progress


### PR DESCRIPTION
The float expansion guard `testFloatExpansionIsLocaleIndependent()` switches `LC_NUMERIC` to a comma-decimal locale and skips when no `de_DE` or `fr_FR` locale is installed. The hosted ubuntu-24.04 images only generate a small set of locales, so the release guard for locale-dependent float corruption can silently skip in CI exactly where 2.0 changed float behavior. This adds a `sudo locale-gen de_DE.UTF-8` step to both test jobs before dependency installation, activating the existing guard without touching runtime code, tests, or documentation. The test itself remains responsible for switching only `LC_NUMERIC` and restoring the previous locale, so Composer and unrelated tests never run under the comma-decimal locale.