### PR TITLE
Classify prefix-on-composite as a value-shape error

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -40,8 +40,13 @@ Missing variables and variables set to `null` are treated as undefined and are
 omitted from the expansion. Empty strings are defined values and are expanded.
 
 Invalid template syntax includes malformed braces, unsupported operators,
-invalid variable names, invalid modifiers, repeated operator-like variable
-specifiers, and prefix modifiers applied to list or map values.
+invalid variable names, invalid modifiers, and repeated operator-like variable
+specifiers.
+
+Prefix modifiers are valid template syntax, but they apply only to scalar or
+stringable referenced values. If a prefix modifier references a defined list or
+map value, expansion throws `InvalidArgumentException`; missing, `null`, empty,
+and all-`null` composites are treated as undefined and omitted.
 
 #### Common Migration Fixes
 


### PR DESCRIPTION
The upgrade guide lists prefix modifiers applied to list or map values under invalid template syntax, but `{list:1}` is valid varspec syntax that parses successfully and expands to an empty string when the referenced variable is missing, `null`, empty, or all-`null`; only a defined list or map value is rejected at expansion time as an unsupported value shape. The distinction matters for optional variables and shared templates that include a prefixed variable which is often omitted. The syntax summary now lists only true parse-time errors, and a short paragraph states both halves of the value-shape rule, matching `docs/input-contract.md`, which already classifies the two cases separately, and the behavior pinned by the existing tests. RFC 6570 frames it the same way: the grammar permits a prefix modifier on any variable name, and the composite restriction is prose-level semantics.