### PR TITLE
Polish 2.0 changelog and docs wrapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,18 +30,18 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 - Fixed path-style parameter explode rendering empty members as `name=` instead of bare `name`
 - Fixed map keys not using the operator's allow set under reserved and fragment expansion
 - Fixed all-null lists and maps throwing with prefix modifiers instead of being skipped as undefined
-- Fixed PCRE engine failures on very long variable names being reported as invalid template syntax
 - Fixed prefix modifiers splitting Unicode code points encoded as multiple pct-encoded triplets
 - Fixed path-style expansion of composites rendering bare `name` instead of `name=` for empty joined members
-- Fixed invalid UTF-8 errors for list and map members not reporting the member path
-- Fixed exception messages embedding raw invalid UTF-8 bytes from map keys
 - Fixed nested query array members set to `null` being rejected for their keys instead of being omitted
 - Fixed float values expanding with the locale decimal separator on PHP versions before 8.0
+- Fixed PCRE engine failures on very long variable names being reported as invalid template syntax
+- Fixed invalid UTF-8 errors for list and map members not reporting the member path
+- Fixed exception messages embedding raw invalid UTF-8 bytes from map keys
 - Fixed exception messages embedding raw invalid UTF-8 bytes from expression text
+- Fixed exception messages embedding raw ASCII control bytes from expression text and map keys
 - Fixed invalid UTF-8 in literal text reporting the offset of the literal segment instead of the first invalid byte
 - Fixed PCRE engine failures during literal text validation being reported as invalid UTF-8
-- Report PCRE engine failures during variable UTF-8 validation as runtime errors
-- Fixed exception messages embedding raw ASCII control bytes from expression text and map keys
+- Fixed PCRE engine failures during variable UTF-8 validation not being reported as runtime errors
 
 ### Removed
 

--- a/docs/input-contract.md
+++ b/docs/input-contract.md
@@ -153,8 +153,8 @@ other empty nested arrays.
 
 ## Validation Errors
 
-Literal text outside expressions must already be valid URI template literal text.
-For example, use `/search%20terms/{id}` instead of `/search terms/{id}`.
+Literal text outside expressions must already be valid URI template literal
+text. For example, use `/search%20terms/{id}` instead of `/search terms/{id}`.
 
 `InvalidArgumentException` is thrown for invalid template syntax, unsupported
 operators, invalid variable names, invalid modifiers, invalid literal text, and


### PR DESCRIPTION
The 2.0 `Fixed` section interleaves diagnostic and reporting entries among behavior fixes, which makes the release-facing summary harder to scan before tagging. This reorders the section so behavior fixes come first and diagnostic and error-reporting fixes follow, grouping the three related raw-byte exception-message entries together, and rewords the one `Report ...` bullet into the section's prevailing `Fixed ...` sentence form. The bullet set is otherwise unchanged, verified as a pure permutation of the existing entries. It also rewraps the one over-80-column prose line in `docs/input-contract.md` without changing its content. No runtime code, tests, or other documentation are touched.