### PR TITLE
Update upstream RFC fixtures

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,17 +35,17 @@
     "require-dev": {
         "bamarni/composer-bin-plugin": "^1.8.2",
         "phpunit/phpunit": "^9.6.34",
-        "uri-template/tests": "1.0.1"
+        "uri-template/tests": "1.0.2"
     },
     "repositories": [
         {
             "type": "package",
             "package": {
                 "name": "uri-template/tests",
-                "version": "1.0.1",
+                "version": "1.0.2",
                 "dist": {
                     "type": "zip",
-                    "url": "https://github.com/uri-templates/uritemplate-test/archive/1eb27ab4462b9e5819dc47db99044f5fd1fa9bc7.zip"
+                    "url": "https://github.com/uri-templates/uritemplate-test/archive/4171dac22aa67fc710b3f6df308a50bd08552986.zip"
                 }
             }
         }


### PR DESCRIPTION
The upstream uritemplate-test repository has merged several new fixture sets since we last updated our pin, covering prefix modifiers with multibyte characters, varspec grammar boundaries, and literal encoding of non-ASCII and pct-encoded literals. This updates the pinned snapshot to the current upstream master so the test suite exercises these new cases, all of which already pass.