### PR TITLE
Report PCRE failures during UTF-8 offset recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 - Fixed invalid UTF-8 in literal text reporting the offset of the literal segment instead of the first invalid byte
 - Fixed PCRE engine failures during literal text validation being reported as invalid UTF-8
 - Fixed PCRE engine failures during variable UTF-8 validation not being reported as runtime errors
+- Fixed PCRE engine failures during invalid UTF-8 offset recovery being reported as invalid UTF-8
 
 ### Removed
 

--- a/docs/input-contract.md
+++ b/docs/input-contract.md
@@ -166,9 +166,10 @@ control bytes are escaped as `\xHH`; when the text contains invalid byte
 sequences, all bytes outside printable ASCII are escaped.
 
 `RuntimeException` is thrown when the PCRE engine fails while processing a
-template, for example when an extremely long variable name exhausts a PCRE
-resource limit. This indicates an environment limit, not invalid input; the
-threshold depends on the PCRE build and `pcre.jit` configuration.
+template, for example when an extremely long variable name or very large
+literal text exhausts a PCRE resource limit. This indicates an environment
+limit, not invalid input; the threshold depends on the PCRE build and
+`pcre.jit` configuration.
 
 Exceptions thrown by a value object's `__toString()` method propagate unchanged;
 they are not converted to `InvalidArgumentException`.

--- a/src/UriTemplate.php
+++ b/src/UriTemplate.php
@@ -886,7 +886,13 @@ final class UriTemplate
             $matches
         );
 
-        return $result === 1 ? \strlen($matches[0]) : 0;
+        if ($result !== 1) {
+            // The pattern matches the empty prefix of every subject, so
+            // anything other than a match is a PCRE engine failure.
+            throw new \RuntimeException(\sprintf('Unable to process template: %s', \preg_last_error_msg()));
+        }
+
+        return \strlen($matches[0]);
     }
 
     private static function isAllowedAsciiLiteral(string $char): bool

--- a/tests/UriTemplateTest.php
+++ b/tests/UriTemplateTest.php
@@ -414,6 +414,29 @@ final class UriTemplateTest extends TestCase
         }
     }
 
+    public function testReportsEngineFailuresDuringLiteralOffsetRecoveryAsRuntimeException(): void
+    {
+        $previous = \ini_get('pcre.backtrack_limit');
+        self::assertNotFalse($previous);
+
+        $caught = null;
+
+        try {
+            // Forces the offset-recovery pattern in validUtf8PrefixLength()
+            // to fail while the primary tokenizer still reports invalid
+            // UTF-8, which PCRE detects before the match limit applies.
+            \ini_set('pcre.backtrack_limit', '0');
+            UriTemplate::expand("A\xC3", []);
+        } catch (\RuntimeException $e) {
+            $caught = $e;
+        } finally {
+            \ini_set('pcre.backtrack_limit', $previous);
+        }
+
+        self::assertNotNull($caught);
+        self::assertStringContainsString('Unable to process template', $caught->getMessage());
+    }
+
     /**
      * @return array<string,array{0:string, 1:array<string,mixed>, 2:string}>
      */


### PR DESCRIPTION
When the literal tokenizer reports invalid UTF-8, validUtf8PrefixLength() runs a second pattern to locate the first invalid byte, but it converted a preg_match() engine failure into byte offset 0. A PCRE resource failure such as an exhausted backtrack limit was therefore misreported as invalid UTF-8 at offset 0 instead of the documented RuntimeException carrying preg_last_error_msg(). The recovery pattern matches the empty prefix of every subject, so any result other than a match is provably an engine failure, and the method now throws the same RuntimeException the surrounding code paths already use. A regression test drives the recovery pattern into a backtrack limit failure while the primary tokenizer still reports invalid UTF-8, and the input contract documentation now mentions very large literal text as another way to exhaust a PCRE resource limit.