### PR TITLE
Warn about untrusted values in reserved expansion

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -304,7 +304,7 @@ members are all `null` is treated as a wholly undefined variable.
 
 Unsupported values throw `InvalidArgumentException` before expansion. This
 includes resources, closures, non-stringable objects, unsupported nested arrays,
-recursive arrays, and arrays nested too deeply.
+recursive arrays, and arrays nested more than 64 levels deep.
 
 Variable values must now be valid UTF-8. Invalid byte sequences throw
 `InvalidArgumentException` instead of being percent-encoded byte by byte. Encode
@@ -503,6 +503,11 @@ UriTemplate::expand('{x}', ['x' => ['a/b' => 'v']]);
 Templates should generally be application-controlled. If templates come from
 users or remote systems, treat them as policy input because template syntax
 controls the structure of the expanded URI.
+
+Values expanded with `{+var}` and `{#var}` keep the URI meaning of reserved
+characters, so untrusted values can inject scheme, authority, path, query, and
+fragment structure into the expanded URI. Use simple expansion for untrusted
+values, or validate them before expansion.
 
 #### UriTemplate Instantiation
 

--- a/docs/input-contract.md
+++ b/docs/input-contract.md
@@ -66,9 +66,15 @@ Arrays whose keys are exactly `0` through `n-1` in ascending insertion order
 expand as lists. All other arrays, including reordered, sparse, and mixed-key
 arrays, expand as maps. Map and list order follows PHP array insertion order.
 
+Because these arrays always expand as lists, a map whose member names are
+exactly the integers `0` through `n-1` cannot be expressed as a single variable
+value; such an array expands as a list. Reference each member with its own
+numeric variable name, such as `{?0,1}`, when the expanded URI must carry those
+names.
+
 Unsupported values include resources, closures, non-stringable objects,
-non-finite floats, recursive arrays, arrays nested too deeply, and nested
-arrays outside exploded query-style expansions. Unsupported values are
+non-finite floats, recursive arrays, arrays nested more than 64 levels deep, and
+nested arrays outside exploded query-style expansions. Unsupported values are
 validated only when the template references that variable.
 
 Variable values must be valid UTF-8. Invalid byte sequences throw
@@ -117,11 +123,12 @@ Nested arrays are accepted only as values inside map variables expanded with an
 exploded query or query-continuation expression, such as `{?filter*}` or
 `{&filter*}`.
 
-Nested query arrays must have scalar leaves. Recursive arrays, arrays nested too
-deeply, and nested objects are rejected. Nested `null` values are treated as
-undefined members and omitted. Omission happens before member validation, so
-the keys of omitted `null` members are not validated. Stringable objects are
-accepted as direct map values, but not as leaves inside nested query arrays.
+Nested query arrays must have scalar leaves and can be nested at most 64 levels
+deep below the top-level map. Recursive arrays, arrays nested more deeply, and
+nested objects are rejected. Nested `null` values are treated as undefined
+members and omitted. Omission happens before member validation, so the keys of
+omitted `null` members are not validated. Stringable objects are accepted as
+direct map values, but not as leaves inside nested query arrays.
 
 Nested query arrays use RFC 3986 query encoding with PHP bracket syntax:
 
@@ -187,6 +194,11 @@ try {
 Templates should generally be application-controlled. If templates come from
 users or remote systems, treat them as policy input and review them before
 expansion.
+
+Values expanded with `{+var}` and `{#var}` keep the URI meaning of reserved
+characters, so untrusted values can inject scheme, authority, path, query, and
+fragment structure into the expanded URI. Use simple expansion for untrusted
+values, or validate them before expansion.
 
 ## Related
 

--- a/docs/uri-template-usage.md
+++ b/docs/uri-template-usage.md
@@ -53,6 +53,11 @@ UriTemplate::expand('/files/{+path}', ['path' => 'a/b']);
 // /files/a/b
 ```
 
+Values expanded with `{+var}` and `{#var}` keep the URI meaning of reserved
+characters, so untrusted values can inject scheme, authority, path, query, and
+fragment structure into the expanded URI. Use simple expansion for untrusted
+values, or validate them before expansion.
+
 Fragment expansion (`{#var}`) prefixes the expanded value with `#` when the
 variable is defined:
 

--- a/tests/UriTemplateTest.php
+++ b/tests/UriTemplateTest.php
@@ -897,6 +897,22 @@ final class UriTemplateTest extends TestCase
         $this->assertInvalidTemplate('{?x*}', ['x' => ['a' => $tooDeep]]);
     }
 
+    public function testAcceptsMaximumDepthArrayVariables(): void
+    {
+        $deepest = 'leaf';
+        $key = 'a';
+
+        for ($i = 0; $i < 64; ++$i) {
+            $deepest = ['x' => $deepest];
+            $key .= '%5Bx%5D';
+        }
+
+        self::assertSame(
+            '?'.$key.'=leaf',
+            UriTemplate::expand('{?x*}', ['x' => ['a' => $deepest]])
+        );
+    }
+
     /**
      * @return array<string,array{0:string, 1:array<string,mixed>, 2:string}>
      */


### PR DESCRIPTION
The usage and upgrade documentation warns that untrusted templates control the structure of the expanded URI but says nothing about untrusted values expanded with `{+var}` and `{#var}`, which preserve the URI meaning of reserved characters and can inject scheme, authority, path, query, and fragment structure into the result. This adds a matching security note, directing untrusted values to simple expansion or prior validation, to the usage guide, the input contract, and the upgrade guide. It also documents the previously unstated 64-level limit on nested query arrays and explains that arrays keyed `0` through `n-1` always expand as lists, so a map with exactly those member names cannot be expressed as a single variable, and it adds a boundary test covering a value nested at exactly the maximum depth.

This builds on #106 and should be merged after it.