### PR TITLE
Treat non-empty all-null lists as defined variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 - Variable values must now be valid UTF-8 and invalid byte sequences throw `InvalidArgumentException`
 - Booleans now expand as `1` and `0` at every nesting level
 - Non-finite floats now throw `InvalidArgumentException` instead of expanding as `INF` or `NAN`
+- Non-empty lists whose members are all null are now treated as defined variables
 - Variable specifier whitespace padding is now detected with the real whitespace set, including form feed
 - `UriTemplate` now rejects native PHP serialization and unserialization
 
@@ -30,7 +31,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 - Fixed path-style parameter explode rendering empty members as `name=` instead of bare `name`
 - Fixed map keys not using the operator's allow set under reserved and fragment expansion
 - Fixed map explode rendering empty members as `name=` instead of bare `name` for unnamed operators
-- Fixed all-null lists and maps throwing with prefix modifiers instead of being skipped as undefined
+- Fixed all-null maps throwing with prefix modifiers instead of being skipped as undefined
 - Fixed prefix modifiers splitting Unicode code points encoded as multiple pct-encoded triplets
 - Fixed path-style expansion of composites rendering bare `name` instead of `name=` for empty joined members
 - Fixed nested query array members set to `null` being rejected for their keys instead of being omitted

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -45,8 +45,9 @@ specifiers.
 
 Prefix modifiers are valid template syntax, but they apply only to scalar or
 stringable referenced values. If a prefix modifier references a defined list or
-map value, expansion throws `InvalidArgumentException`; missing, `null`, empty,
-and all-`null` composites are treated as undefined and omitted.
+map value, including a non-empty list whose members are all `null`, expansion
+throws `InvalidArgumentException`; missing and `null` variables, empty arrays,
+and maps whose members are all `null` are treated as undefined and omitted.
 
 #### Common Migration Fixes
 
@@ -299,8 +300,29 @@ Nested arrays in maps are supported for exploded query-style expansions, such as
 `null` members inside lists and maps are treated as undefined and omitted,
 consistent with top-level `null`. RFC 6570 section 3.2.1 expands a list as a
 concatenation of "the defined member string values", and section 2.4.2 states
-that "only the defined pairs are present in the expansion". A list or map whose
-members are all `null` is treated as a wholly undefined variable.
+that "only the defined pairs are present in the expansion". A map whose members
+are all `null` is treated as a wholly undefined variable, because RFC 6570
+section 2.3 considers an associative array undefined when all member names are
+associated with undefined values. A non-empty list whose members are all `null`
+is a defined variable with no defined members, because the same section calls a
+list undefined only when it contains zero members: the operator first string is
+still emitted, named forms render the name with the operator's empty-value
+form, and prefix modifiers are rejected as for any other list.
+
+Guzzle URI Template 1.x agreed with 2.0 on most expansions of such lists,
+including the `#`, `.`, and `/` first strings, `?l=`, `&l=`, and `;l`. 1.x
+differed on the exploded named forms, rendering `;l`, `?l=`, and `&l=` where
+2.0 renders `;`, `?`, and `&`, on lists mixing `null` and defined members,
+where 1.x expanded `[null, 'x']` as `,x` while 2.0 omits the `null` member and
+expands `x`, and on prefix modifiers, where 1.x expanded `{l:1}` with an
+all-`null` list as an empty string while 2.0 throws `InvalidArgumentException`:
+
+```php
+UriTemplate::expand('{/l}{;l}{;l*}', ['l' => [null]]);
+
+// 1.x: /;l;l
+// 2.0: /;l;
+```
 
 Unsupported values throw `InvalidArgumentException` before expansion. This
 includes resources, closures, non-stringable objects, unsupported nested arrays,

--- a/docs/input-contract.md
+++ b/docs/input-contract.md
@@ -54,11 +54,15 @@ undefined and omitted. Missing variables and variables set to `null` are treated
 as undefined and omitted.
 
 `null` members inside lists and maps are treated as undefined members and
-omitted, like top-level `null`. A list or map whose members are all `null` is
-treated as undefined and omitted, like an empty array. A list or map with at
-least one defined member is a defined, non-empty value: in named non-exploded
-expansions, `=` follows the name even when every member expands to the empty
-string, so `{;l}` with `['l' => ['']]` expands to `;l=`. See the [conformance
+omitted, like top-level `null`. A map whose members are all `null` is treated
+as undefined and omitted, like an empty array. A non-empty list whose members
+are all `null` is a defined variable with no defined members: the operator
+first string is still emitted, named forms render the name with the operator's
+empty-value form, and prefix modifiers are rejected as for any other list. A
+list or map with at least one defined member is a defined, non-empty value: in
+named non-exploded expansions, `=` follows the name even when every member
+expands to the empty string, so `{;l}` with `['l' => ['']]` expands to `;l=`.
+See the [conformance
 notes](uri-template-usage.md#specification-conformance-notes) for how the
 all-`null` rule maps to RFC 6570.
 

--- a/docs/uri-template-usage.md
+++ b/docs/uri-template-usage.md
@@ -160,8 +160,9 @@ UriTemplate::expand('/search{?filter*}', [
 
 Empty nested arrays are omitted from exploded query expansions. `null` members
 inside lists and maps are treated as undefined members and omitted, like
-top-level `null`. A list or map whose members are all `null` is treated as
-undefined, as described in the [specification conformance
+top-level `null`. A map whose members are all `null` is treated as undefined,
+while a non-empty list whose members are all `null` is a defined variable with
+no defined members, as described in the [specification conformance
 notes](#specification-conformance-notes).
 
 Variable values are encoded during expansion according to the expression type.
@@ -211,14 +212,15 @@ Variable values must be valid UTF-8, per RFC 6570 section 1.6. Invalid byte
 sequences throw `InvalidArgumentException`, as described in the [input
 contract](input-contract.md#values).
 
-Defined lists and maps are never empty values in named non-exploded
-expansions. RFC 6570 section 2.3 treats a list as undefined only when it
-contains zero members, and the appendix A algorithm tests the value for
-emptiness before its members are joined, so `{;l}` expanded with
-`['l' => ['']]` produces `;l=` rather than `;l`. Several other implementations
-test the comma-joined member string instead and omit the `=`, so path-style
-expansions of composite values whose members all expand empty can differ
-between libraries.
+A defined composite value is empty in named non-exploded expansions only when
+it contains no defined members. RFC 6570 section 2.3 treats a list as undefined
+only when it contains zero members, and the appendix A algorithm tests the
+value for emptiness before its members are joined, so `{;l}` expanded with
+`['l' => ['']]` produces `;l=` rather than `;l`, while `{;l}` expanded with
+`['l' => [null]]` produces `;l`. Several other implementations test the
+comma-joined member string instead and omit the `=`, so path-style expansions
+of composite values whose members all expand empty can differ between
+libraries.
 
 Exploded map members with empty-string values render as the bare name under the
 simple, reserved (`+`), fragment (`#`), label (`.`), and path segment (`/`)
@@ -234,15 +236,20 @@ applies the same rule through its ifemp string, so `{;x*}` with an empty-string
 member produces a bare name, while the form-style `{?x*}` and `{&x*}` keep
 `name=`.
 
-A list or map whose members are all `null` is treated as a wholly undefined
-variable, so it is omitted together with the operator's first character unless
-another variable in the expression is defined. RFC 6570 section 2.3 states
-this rule only for associative arrays, which are "considered undefined if the
-array contains zero members or if all member names in the array are associated
-with undefined values"; a list is called undefined only "if the list contains
-zero members". This library maps `null` members to undefined members, and
-skipping every undefined member leaves a list with zero members, so the same
-rule applies to lists.
+A map whose members are all `null` is treated as a wholly undefined variable,
+so it is omitted together with the operator's first character unless another
+variable in the expression is defined. RFC 6570 section 2.3 considers an
+associative array undefined "if the array contains zero members or if all
+member names in the array are associated with undefined values". A list whose
+members are all `null` is instead a defined variable with no defined members:
+RFC 6570 calls a list undefined only when it contains zero members and reserves
+the all-members-undefined rule for associative arrays. Such a list expands to
+an empty member list, so the operator first string is still emitted, named
+forms render the name with the operator's empty-value form, and prefix
+modifiers are rejected as for any other list. This is a revised conformance
+decision where the RFC is ambiguous; there is no ecosystem consensus for these
+inputs, and some implementations, such as std-uritemplate, reject them
+outright.
 
 No Unicode normalization is applied to templates or variable values. RFC 6570
 section 1.6 states that a value provided by a user "SHOULD be normalized as

--- a/src/UriTemplate.php
+++ b/src/UriTemplate.php
@@ -182,17 +182,19 @@ final class UriTemplate
 
             $actuallyUseQuery = $useQuery;
             $expanded = '';
+            $kvp = [];
 
             if (\is_array($variable)) {
                 $isAssoc = self::isAssoc($variable);
-                $kvp = [];
                 /** @var mixed $var */
                 foreach ($variable as $key => $var) {
                     if ($var === null) {
                         // Spec section 3.2.1: a list expands "the defined
                         // member string values", and spec section 2.4.2:
                         // "only the defined pairs are present in the
-                        // expansion", so undefined members are skipped.
+                        // expansion", so undefined members are skipped. A
+                        // list whose members are all skipped stays defined
+                        // and expands to an empty member list.
                         continue;
                     }
 
@@ -247,13 +249,13 @@ final class UriTemplate
                     $kvp[] = (string) $var;
                 }
 
-                if ($kvp === []) {
-                    // A composite with no defined members is treated as an
-                    // undefined variable. Spec section 2.3 states this for
-                    // associative arrays only; extending it to lists whose
-                    // members are all null is a documented conformance
-                    // decision, since the spec calls a list undefined only
-                    // when it contains zero members.
+                if ($kvp === [] && $isAssoc) {
+                    // Spec section 2.3: a map whose member names are all
+                    // associated with undefined values is undefined. Nested
+                    // query maps whose members are all empty or all-null
+                    // nested arrays reach this point because those members
+                    // are arrays rather than null, so they are skipped here
+                    // instead of in isUndefinedVariable().
                     continue;
                 } elseif ($value['modifier'] === '*') {
                     $expanded = \implode($joiner, $kvp);
@@ -276,12 +278,20 @@ final class UriTemplate
 
             if ($actuallyUseQuery) {
                 if (\is_array($variable)) {
-                    // Spec sections 2.3 and 3.2.7 and appendix A: emptiness
-                    // is tested on the variable's value before expansion, and
-                    // a defined list or map is never an empty value, so "="
-                    // is appended even when every member expands to the empty
-                    // string.
-                    $expanded = \sprintf('%s=%s', $value['value'], $expanded);
+                    if ($kvp === []) {
+                        // Spec section 3.2.7: "=" is appended only for a
+                        // non-empty value, and a composite value is empty
+                        // only when it contains no defined members, so the
+                        // operator's ifemp string is used instead.
+                        $expanded = $value['value'].$ifemp;
+                    } else {
+                        // Spec sections 2.3 and 3.2.7 and appendix A:
+                        // emptiness is tested on the variable's value before
+                        // expansion, and a composite with a defined member
+                        // is never an empty value, so "=" is appended even
+                        // when every member expands to the empty string.
+                        $expanded = \sprintf('%s=%s', $value['value'], $expanded);
+                    }
                 } else {
                     $expanded = self::formatPair($value['value'], $expanded, $ifemp);
                 }
@@ -486,12 +496,13 @@ final class UriTemplate
     /**
      * Determines if a referenced variable is undefined.
      *
-     * Spec section 2.3: a list is undefined when it contains zero members,
-     * and a map is undefined when it contains zero members or when all
-     * member names are associated with undefined values. Lists whose
-     * members are all null are treated the same way, like an empty list.
-     * Spec section 3.2.1: undefined variables are ignored by the expansion
-     * process, so they are skipped before varspec shape validation.
+     * Spec section 2.3: a list is undefined only when it contains zero
+     * members, while a map is undefined when it contains zero members or
+     * when all member names are associated with undefined values. A
+     * non-empty list whose members are all null is therefore a defined
+     * variable with no defined members. Spec section 3.2.1: undefined
+     * variables are ignored by the expansion process, so they are skipped
+     * before varspec shape validation.
      *
      * @param array<string, mixed> $variables
      */
@@ -502,6 +513,14 @@ final class UriTemplate
         }
 
         if (!\is_array($variables[$name])) {
+            return false;
+        }
+
+        if ($variables[$name] === []) {
+            return true;
+        }
+
+        if (!self::isAssoc($variables[$name])) {
             return false;
         }
 

--- a/tests/UriTemplateTest.php
+++ b/tests/UriTemplateTest.php
@@ -654,6 +654,8 @@ final class UriTemplateTest extends TestCase
             'matrix map' => ['{;keys:1}', ['keys' => ['semi' => ';']]],
             'list with null member' => ['{x:1}', ['x' => ['red', null]]],
             'map with null member' => ['{x:1}', ['x' => ['a' => null, 'b' => 'v']]],
+            'all null list' => ['{x:1}', ['x' => [null]]],
+            'path all null list' => ['{/x:3}', ['x' => [null, null]]],
         ];
     }
 
@@ -677,30 +679,62 @@ final class UriTemplateTest extends TestCase
     /**
      * @return array<string,array{0:string, 1:array<string,mixed>, 2:string}>
      */
-    public static function allNullCompositeProvider(): array
+    public static function allNullMapProvider(): array
     {
         return [
             'prefix on all null map' => ['{x:1}', ['x' => ['a' => null]], ''],
-            'prefix on all null list' => ['{x:1}', ['x' => [null]], ''],
-            'path prefix on all null list' => ['{/x:3}', ['x' => [null, null]], ''],
             'query prefix on all null map' => ['{?x:2}', ['x' => ['a' => null]], ''],
             'label prefix on all null map' => ['X{.x:1}', ['x' => ['a' => null]], 'X'],
             'remaining variables still expand' => ['{x:1,y}', ['x' => ['a' => null], 'y' => 'v'], 'v'],
-            'all null list path' => ['{/x}', ['x' => [null]], ''],
-            'all null list query' => ['{?x}', ['x' => [null]], ''],
-            'all null list exploded query' => ['{?x*}', ['x' => [null]], ''],
-            'all null list multiple members' => ['{?l}', ['l' => [null, null]], ''],
             'all null map query' => ['{?m}', ['m' => ['k' => null]], ''],
-            'all null list beside defined variable' => ['{/x,y}', ['x' => [null], 'y' => 'z'], '/z'],
         ];
     }
 
     /**
-     * @dataProvider allNullCompositeProvider
+     * @dataProvider allNullMapProvider
      *
      * @param array<string,mixed> $variables
      */
-    public function testTreatsAllNullCompositesAsUndefined(string $template, array $variables, string $expansion): void
+    public function testTreatsAllNullMapsAsUndefined(string $template, array $variables, string $expansion): void
+    {
+        self::assertSame($expansion, UriTemplate::expand($template, $variables));
+    }
+
+    /**
+     * @return array<string,array{0:string, 1:array<string,mixed>, 2:string}>
+     */
+    public static function allNullListProvider(): array
+    {
+        return [
+            'simple' => ['{l}', ['l' => [null]], ''],
+            'simple exploded' => ['{l*}', ['l' => [null]], ''],
+            'reserved' => ['{+l}', ['l' => [null]], ''],
+            'reserved exploded' => ['{+l*}', ['l' => [null]], ''],
+            'fragment' => ['{#l}', ['l' => [null]], '#'],
+            'fragment exploded' => ['{#l*}', ['l' => [null]], '#'],
+            'label' => ['{.l}', ['l' => [null]], '.'],
+            'label exploded' => ['{.l*}', ['l' => [null]], '.'],
+            'path' => ['{/l}', ['l' => [null]], '/'],
+            'path exploded' => ['{/l*}', ['l' => [null]], '/'],
+            'path style' => ['{;l}', ['l' => [null]], ';l'],
+            'path style exploded' => ['{;l*}', ['l' => [null]], ';'],
+            'query' => ['{?l}', ['l' => [null]], '?l='],
+            'query exploded' => ['{?l*}', ['l' => [null]], '?'],
+            'query continuation' => ['{&l}', ['l' => [null]], '&l='],
+            'query continuation exploded' => ['{&l*}', ['l' => [null]], '&'],
+            'multiple null members' => ['{?l}', ['l' => [null, null]], '?l='],
+            'mixed null and defined members' => ['{l}', ['l' => [null, 'x']], 'x'],
+            'beside defined variable' => ['{x,y}', ['x' => [null], 'y' => 'z'], ',z'],
+            'path beside defined variable' => ['{/x,y}', ['x' => [null], 'y' => 'z'], '//z'],
+        ];
+    }
+
+    /**
+     * @dataProvider allNullListProvider
+     *
+     * @param array<string,mixed> $variables
+     */
+    public function testTreatsAllNullListsAsDefined(string $template, array $variables, string $expansion): void
     {
         self::assertSame($expansion, UriTemplate::expand($template, $variables));
     }
@@ -729,7 +763,7 @@ final class UriTemplateTest extends TestCase
             'null map member skipped' => ['{?x*}', ['x' => ['a' => null, 'b' => 'c']], '?b=c'],
             'null member in simple list' => ['{x}', ['x' => ['red', null, 'blue']], 'red,blue'],
             'all null map members undefined' => ['X{.x}', ['x' => ['a' => null]], 'X'],
-            'all null list members undefined' => ['{#x}', ['x' => [null]], ''],
+            'all null list members defined' => ['{#x}', ['x' => [null]], '#'],
             'null nested query leaf skipped' => ['{?x*}', ['x' => ['a' => ['b' => null, 'c' => 'v']]], '?a%5Bc%5D=v'],
             'null member with invalid utf-8 key skipped' => ['{?x*}', ['x' => ["\xC3\x28" => null, 'kept' => 'v']], '?kept=v'],
             'nested null member with invalid utf-8 key skipped' => ['{?x*}', ['x' => ['k' => ["\xC3\x28" => null], 'kept' => 'v']], '?kept=v'],


### PR DESCRIPTION
RFC 6570 section 2.3 calls a list undefined only when it contains zero members and reserves the all-members-undefined rule for associative arrays, so a non-empty list whose members are all null is a defined variable with no defined members. Expansion now emits the operator first string for such lists, renders named forms with the operator empty-value form, and rejects them under prefix modifiers like any other composite, while maps whose members are all null stay undefined. This is a revised conformance decision where the RFC is ambiguous, and the documentation, changelog, and upgrade guide present it as such, including the 1.x comparison. This builds on #107 and should be merged after it.