### PR TITLE
Form variable values before expansion begins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 - Non-empty lists whose members are all null are now treated as defined variables
 - Variable specifier whitespace padding is now detected with the real whitespace set, including form feed
 - `UriTemplate` now rejects native PHP serialization and unserialization
+- Referenced variable values are now detached and formed before expansion begins
+- Template syntax is now validated for every expression before variable values are formed
+- Stringable objects are now converted to strings once per value position while values are formed
+- Invalid UTF-8 in variable values and map keys is now rejected while values are formed
+- Finite floats are now converted to their expansion strings while values are formed
+- Exceptions thrown by `__toString()` now surface while values are formed, before any output exists
 
 ### Fixed
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -352,6 +352,38 @@ UriTemplate::expand('/events{?date}', [
 ]);
 ```
 
+Referenced variable values are detached from the variables array and formed
+before expansion begins, as required by RFC 6570 section 3. Definedness is
+bound and raw values are read before any `__toString()` method runs, so an
+object cannot change another referenced variable through a PHP reference.
+Stringable objects are then converted to strings once per value position, in
+template order, and scalars are converted to their expansion strings, so a
+repeated variable keeps a static value even when a `__toString()` method
+changes the float precision or the locale mid-expansion. String values and
+map keys are validated as UTF-8 while values are formed, so value errors
+surface in member order. Guzzle URI Template 1.x called
+`__toString()` again for every occurrence, so an object returning different
+values could expand differently within one template. Exceptions thrown by
+`__toString()` propagate unchanged; they surface while values are formed,
+after template syntax validation and before any part of the URI is produced,
+and may preempt validation errors for values formed later:
+
+```php
+$counter = new class() {
+    private $n = 0;
+
+    public function __toString(): string
+    {
+        return (string) ++$this->n;
+    }
+};
+
+UriTemplate::expand('{x}-{x}', ['x' => $counter]);
+
+// 1.x: 1-2
+// 2.0: 1-1
+```
+
 #### Array Values
 
 PHP arrays are classified by shape. Arrays whose keys are exactly `0` through

--- a/docs/input-contract.md
+++ b/docs/input-contract.md
@@ -35,6 +35,19 @@ Supported variable values are:
 - maps containing scalar or stringable values
 - nested arrays in maps for exploded query-style expansions, with scalar leaves
 
+Referenced variable values are detached from the variables array and formed
+before expansion begins. Definedness is bound and raw values are read before
+any `__toString()` method runs, so an object cannot change another referenced
+variable through a PHP reference. Stringable objects are then converted to
+strings once per value position, in template order, and scalars are converted
+to their expansion strings, so a repeated variable keeps a static value even
+when a `__toString()` method changes the float precision or the locale
+mid-expansion. String values and map keys are validated as UTF-8 while values
+are formed, so value errors surface in member order. Exceptions thrown by `__toString()` propagate unchanged; they
+surface while values are formed, after template syntax validation and before
+any part of the URI is produced, and may preempt validation errors for values
+formed later.
+
 Booleans expand as `1` and `0` at every nesting level.
 
 Floats expand using PHP's float-to-string conversion with the decimal separator
@@ -183,7 +196,9 @@ limit, not invalid input; the threshold depends on the PCRE build and
 `pcre.jit` configuration.
 
 Exceptions thrown by a value object's `__toString()` method propagate unchanged;
-they are not converted to `InvalidArgumentException`.
+they are not converted to `InvalidArgumentException`. They surface while values
+are formed, once per expansion, after template syntax validation and before any
+part of the URI is produced.
 
 Catch `InvalidArgumentException` if templates or values come from outside your
 application:

--- a/docs/input-contract.md
+++ b/docs/input-contract.md
@@ -43,10 +43,10 @@ strings once per value position, in template order, and scalars are converted
 to their expansion strings, so a repeated variable keeps a static value even
 when a `__toString()` method changes the float precision or the locale
 mid-expansion. String values and map keys are validated as UTF-8 while values
-are formed, so value errors surface in member order. Exceptions thrown by `__toString()` propagate unchanged; they
-surface while values are formed, after template syntax validation and before
-any part of the URI is produced, and may preempt validation errors for values
-formed later.
+are formed, so value errors surface in member order. Exceptions thrown by
+`__toString()` propagate unchanged; they surface while values are formed, after
+template syntax validation and before any part of the URI is produced, and may
+preempt validation errors for values formed later.
 
 Booleans expand as `1` and `0` at every nesting level.
 

--- a/src/UriTemplate.php
+++ b/src/UriTemplate.php
@@ -66,14 +66,13 @@ final class UriTemplate
             return $template;
         }
 
-        $expressions = self::parseExpressions($references);
-        $values = self::formValues($references, $expressions, $variables);
+        $values = self::formValues($references, $variables);
 
         /** @var string|null */
         $result = \preg_replace_callback(
             '/\{([^\}]+)\}/',
-            static function (array $matches) use ($expressions, $values): string {
-                return self::expandMatch($matches, $expressions, $values);
+            static function (array $matches) use ($values): string {
+                return self::expandMatch($matches, $values);
             },
             $template
         );
@@ -86,88 +85,232 @@ final class UriTemplate
     }
 
     /**
-     * Parse and validate every expression of the template, in template order.
-     *
-     * Expression text such as "0" is a canonical decimal integer string,
-     * which PHP stores under an integer array key.
-     *
-     * @param list<string> $references The expression text of each expression, in template order
-     *
-     * @return array<array-key, array{operator:string, values:array<array{value:string, modifier:(''|'*'|':'), position?:int}>}>
-     */
-    private static function parseExpressions(array $references): array
-    {
-        $expressions = [];
-
-        foreach ($references as $expression) {
-            if (!isset($expressions[$expression])) {
-                $expressions[$expression] = self::parseExpression($expression);
-            }
-        }
-
-        return $expressions;
-    }
-
-    /**
      * Detach and form every referenced variable value before expansion.
      *
      * Spec section 3: each variable's value is formed prior to template
-     * expansion. Definedness is bound and raw values are detached, in
-     * template order, before any __toString() method runs, so an object
-     * converted while values are formed cannot change another referenced
-     * variable through a PHP reference. Stringable objects are then
-     * converted to strings and scalars to their expansion strings, once
-     * per value position, in template order, and string values and map
-     * keys are validated as UTF-8 in the same pass, so a repeated variable
-     * keeps a static value throughout the expansion and value errors
-     * surface in member order. Undefined variables are stored as null.
+     * expansion. Every expression is parsed and validated first, then
+     * definedness is bound and raw values are read, in template order,
+     * before any __toString() method runs, so an object converted while
+     * values are formed cannot change another referenced variable through
+     * a PHP reference. Stringable objects are converted to strings and
+     * scalars to their expansion strings, once per value position, in
+     * template order, and string values and map keys are validated as
+     * UTF-8 in the same pass, so a repeated variable keeps a static value
+     * throughout the expansion and value errors surface in member order.
+     * Undefined variables are stored as null.
      *
-     * @param list<string>                                                                                                      $references  The expression text of each expression, in template order
-     * @param array<array-key, array{operator:string, values:array<array{value:string, modifier:(''|'*'|':'), position?:int}>}> $expressions
-     * @param array<array-key, mixed>                                                                                           $variables
+     * Values containing no references, floats, or stringable objects, and
+     * values whose shape is certain to be rejected, are shared instead of
+     * being rebuilt: copy-on-write semantics guarantee shared values
+     * cannot change, and sharing avoids materializing structures whose
+     * logical size exceeds their physical size, such as arrays repeating
+     * one shared subtree. Parsed expressions are not retained; expansion
+     * parses each occurrence again, so templates with many distinct
+     * expressions do not allocate storage proportional to their count.
+     *
+     * @param list<string>            $references The distinct expression text, in first-occurrence order
+     * @param array<array-key, mixed> $variables
      *
      * @return array<array-key, mixed>
      */
-    private static function formValues(array $references, array $expressions, array $variables): array
+    private static function formValues(array $references, array $variables): array
     {
-        /** @var array<array-key, mixed> $detached */
-        $detached = [];
-        /** @var list<array{string, array{value:string, modifier:(''|'*'|':'), position?:int}, string, string}> $order */
+        /** @var array<array-key, mixed> $values */
+        $values = [];
+        /** @var list<array{string, array{value:string, modifier:(''|'*'|':'), position?:int}, string, string, bool}> $order */
         $order = [];
 
         foreach ($references as $expression) {
-            foreach ($expressions[$expression]['values'] as $varspec) {
+            $parsed = self::parseExpression($expression);
+
+            foreach ($parsed['values'] as $varspec) {
                 $name = $varspec['value'];
 
-                if (\array_key_exists($name, $detached)) {
+                if (\array_key_exists($name, $values)) {
                     continue;
                 }
 
                 if (self::isUndefinedVariable($variables, $name)) {
-                    $detached[$name] = null;
+                    $values[$name] = null;
                     continue;
                 }
 
-                $operator = $expressions[$expression]['operator'];
                 /** @var mixed $raw */
                 $raw = $variables[$name];
-                $membersMayNest = \is_array($raw)
-                    && $varspec['modifier'] === '*'
-                    && ($operator === '?' || $operator === '&')
-                    && self::isAssoc($raw);
+                $form = self::valueNeedsForming($raw, 0)
+                    && !self::shapeGuaranteesRejection($varspec, $raw, $parsed['operator']);
 
-                $detached[$name] = self::detachValue($raw, $membersMayNest, 0);
-                $order[] = [$name, $varspec, $expression, $operator];
+                if ($form) {
+                    $membersMayNest = \is_array($raw)
+                        && $varspec['modifier'] === '*'
+                        && ($parsed['operator'] === '?' || $parsed['operator'] === '&')
+                        && self::isAssoc($raw);
+                    /** @var mixed $raw */
+                    $raw = self::detachValue($raw, $membersMayNest, 0);
+                }
+
+                $values[$name] = $raw;
+                $order[] = [$name, $varspec, $expression, $parsed['operator'], $form];
             }
         }
 
-        $values = $detached;
-
-        foreach ($order as [$name, $varspec, $expression, $operator]) {
-            $values[$name] = self::normalizeVariableShape($varspec, $detached[$name], $expression, $operator);
+        foreach ($order as [$name, $varspec, $expression, $operator, $form]) {
+            if ($form) {
+                $values[$name] = self::normalizeVariableShape($varspec, $values[$name], $expression, $operator);
+            } else {
+                self::assertVariableShape($varspec, $values[$name], $expression, $operator);
+            }
         }
 
         return $values;
+    }
+
+    /**
+     * Determine whether a value must be detached and rebuilt to be formed.
+     *
+     * Only PHP references can change an array's contents after it has been
+     * read, and only floats and stringable objects need eager conversion,
+     * so a value containing none of the three is shared as it is. Levels
+     * beyond the nesting limit are not scanned; shapes that deep are
+     * always rejected by validation before their contents are read.
+     *
+     * @param mixed $value
+     */
+    private static function valueNeedsForming($value, int $depth): bool
+    {
+        if (\is_float($value)) {
+            return true;
+        }
+
+        if (\is_object($value)) {
+            return \method_exists($value, '__toString');
+        }
+
+        if (!\is_array($value) || $depth > self::MAX_VARIABLE_DEPTH + 1) {
+            return false;
+        }
+
+        /** @var mixed $member */
+        foreach ($value as $key => $member) {
+            if (\ReflectionReference::fromArrayElement($value, $key) !== null
+                || self::valueNeedsForming($member, $depth + 1)
+            ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Determine whether shape validation is certain to reject a value.
+     *
+     * Mirrors the shape rules without messages, encoding checks, or user
+     * code, and stops at the first guaranteed rejection, so cyclic or
+     * copy-on-write shared structures that can never expand are rejected
+     * by walking them instead of being rebuilt first.
+     *
+     * @param array{value:string, modifier:(''|'*'|':'), position?:int} $varspec
+     * @param mixed                                                     $variable
+     */
+    private static function shapeGuaranteesRejection(array $varspec, $variable, string $operator): bool
+    {
+        if (self::isScalarLike($variable)) {
+            return \is_float($variable) && !\is_finite($variable);
+        }
+
+        if (!\is_array($variable)) {
+            return true;
+        }
+
+        if ($varspec['modifier'] === ':') {
+            return true;
+        }
+
+        if (!self::isAssoc($variable)) {
+            /** @var mixed $member */
+            foreach ($variable as $member) {
+                if ($member !== null && !self::isScalarLike($member)) {
+                    return true;
+                }
+
+                if (\is_float($member) && !\is_finite($member)) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        $allowNestedArrays = $varspec['modifier'] === '*' && ($operator === '?' || $operator === '&');
+
+        return self::mapShapeGuaranteesRejection($variable, $allowNestedArrays, 0);
+    }
+
+    /**
+     * @param array<array-key, mixed> $value
+     */
+    private static function mapShapeGuaranteesRejection(array $value, bool $allowNestedArrays, int $depth): bool
+    {
+        if ($depth > self::MAX_VARIABLE_DEPTH) {
+            return true;
+        }
+
+        /** @var mixed $member */
+        foreach ($value as $member) {
+            if ($member === null || self::isScalarLike($member)) {
+                if (\is_float($member) && !\is_finite($member)) {
+                    return true;
+                }
+
+                continue;
+            }
+
+            if (\is_array($member) && $allowNestedArrays) {
+                if (self::nestedQueryShapeGuaranteesRejection($member, $depth + 1)) {
+                    return true;
+                }
+
+                continue;
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * @param array<array-key, mixed> $value
+     */
+    private static function nestedQueryShapeGuaranteesRejection(array $value, int $depth): bool
+    {
+        if ($depth > self::MAX_VARIABLE_DEPTH) {
+            return true;
+        }
+
+        /** @var mixed $member */
+        foreach ($value as $member) {
+            if ($member === null || \is_scalar($member)) {
+                if (\is_float($member) && !\is_finite($member)) {
+                    return true;
+                }
+
+                continue;
+            }
+
+            if (\is_array($member)) {
+                if (self::nestedQueryShapeGuaranteesRejection($member, $depth + 1)) {
+                    return true;
+                }
+
+                continue;
+            }
+
+            return true;
+        }
+
+        return false;
     }
 
     /**
@@ -281,16 +424,15 @@ final class UriTemplate
     /**
      * Process an expansion
      *
-     * @param array{0: string, 1: string}                                                                                       $matches     Matches met in the preg_replace_callback
-     * @param array<array-key, array{operator:string, values:array<array{value:string, modifier:(''|'*'|':'), position?:int}>}> $expressions Parsed expressions of the template
-     * @param array<array-key, mixed>                                                                                           $values      Variable values formed before the expansion began
+     * @param array{0: string, 1: string} $matches Matches met in the preg_replace_callback
+     * @param array<array-key, mixed>     $values  Variable values formed before the expansion began
      *
      * @return string Returns the replacement string
      */
-    private static function expandMatch(array $matches, array $expressions, array $values): string
+    private static function expandMatch(array $matches, array $values): string
     {
         $replacements = [];
-        $parsed = $expressions[$matches[1]];
+        $parsed = self::parseExpression($matches[1]);
         $prefix = self::OPERATOR_HASH[$parsed['operator']]['prefix'];
         $joiner = self::OPERATOR_HASH[$parsed['operator']]['joiner'];
         $useQuery = self::OPERATOR_HASH[$parsed['operator']]['query'];
@@ -310,7 +452,7 @@ final class UriTemplate
             // rule, run on every occurrence against the formed value, so an
             // occurrence with an inapplicable modifier throws no matter
             // where it appears in the template.
-            self::normalizeVariableShape($value, $variable, $matches[1], $parsed['operator']);
+            self::assertVariableShape($value, $variable, $matches[1], $parsed['operator']);
 
             $actuallyUseQuery = $useQuery;
             $expanded = '';
@@ -677,6 +819,192 @@ final class UriTemplate
     }
 
     /**
+     * Validate a variable value against a varspec without rebuilding it.
+     *
+     * Values that were shared instead of formed contain no references,
+     * floats, or stringable objects, so validating them in place is
+     * sufficient, and later occurrences of every variable re-run the
+     * varspec-specific checks, such as the prefix-on-composite rule,
+     * against the already formed value.
+     *
+     * @param array{value:string, modifier:(''|'*'|':'), position?:int} $varspec
+     * @param mixed                                                     $variable
+     */
+    private static function assertVariableShape(array $varspec, $variable, string $expression, string $operator): void
+    {
+        if (self::isScalarLike($variable)) {
+            if (\is_float($variable) && !\is_finite($variable)) {
+                throw self::invalidVariable($expression, $varspec['value'], 'non-finite floats are not supported');
+            }
+
+            if (\is_string($variable)) {
+                self::assertValidVariableUtf8($variable, $expression, $varspec['value']);
+            }
+
+            return;
+        }
+
+        if (!\is_array($variable)) {
+            throw self::invalidVariable(
+                $expression,
+                $varspec['value'],
+                \sprintf(
+                    'expected scalar, stringable object, list, or associative array; got %s',
+                    \get_debug_type($variable)
+                )
+            );
+        }
+
+        if ($varspec['modifier'] === ':') {
+            throw self::invalidVariable(
+                $expression,
+                $varspec['value'],
+                'prefix modifier is not applicable to composite values'
+            );
+        }
+
+        if (!self::isAssoc($variable)) {
+            self::assertListShape($varspec['value'], $variable, $expression);
+
+            return;
+        }
+
+        $allowNestedArrays = $varspec['modifier'] === '*' && ($operator === '?' || $operator === '&');
+
+        self::assertMapShape($varspec['value'], $variable, $expression, $allowNestedArrays, 0);
+    }
+
+    /**
+     * @param array<array-key, mixed> $value
+     */
+    private static function assertListShape(string $path, array $value, string $expression): void
+    {
+        /** @var mixed $member */
+        foreach ($value as $index => $member) {
+            if ($member === null) {
+                continue;
+            }
+
+            $memberPath = \sprintf('%s[%d]', $path, $index);
+
+            if (self::isScalarLike($member)) {
+                if (\is_float($member) && !\is_finite($member)) {
+                    throw self::invalidVariable($expression, $memberPath, 'non-finite floats are not supported');
+                }
+
+                if (\is_string($member)) {
+                    self::assertValidVariableUtf8($member, $expression, $memberPath);
+                }
+
+                continue;
+            }
+
+            throw self::invalidVariable(
+                $expression,
+                $memberPath,
+                \sprintf('expected scalar or stringable object; got %s', \get_debug_type($member))
+            );
+        }
+    }
+
+    /**
+     * @param array<array-key, mixed> $value
+     */
+    private static function assertMapShape(
+        string $path,
+        array $value,
+        string $expression,
+        bool $allowNestedArrays,
+        int $depth
+    ): void {
+        if ($depth > self::MAX_VARIABLE_DEPTH) {
+            throw self::invalidVariable($expression, $path, 'maximum variable nesting depth exceeded');
+        }
+
+        /** @var mixed $member */
+        foreach ($value as $key => $member) {
+            if ($member === null) {
+                continue;
+            }
+
+            $memberPath = \sprintf('%s[%s]', $path, (string) $key);
+
+            if (\is_string($key)) {
+                self::assertValidVariableUtf8($key, $expression, $memberPath);
+            }
+
+            if (self::isScalarLike($member)) {
+                if (\is_float($member) && !\is_finite($member)) {
+                    throw self::invalidVariable($expression, $memberPath, 'non-finite floats are not supported');
+                }
+
+                if (\is_string($member)) {
+                    self::assertValidVariableUtf8($member, $expression, $memberPath);
+                }
+
+                continue;
+            }
+
+            if (\is_array($member) && $allowNestedArrays) {
+                self::assertNestedQueryShape($memberPath, $member, $expression, $depth + 1);
+                continue;
+            }
+
+            throw self::invalidVariable(
+                $expression,
+                $memberPath,
+                \sprintf('expected scalar%s; got %s', $allowNestedArrays ? ', stringable object, or nested array' : ' or stringable object', \get_debug_type($member))
+            );
+        }
+    }
+
+    /**
+     * @param array<array-key, mixed> $value
+     */
+    private static function assertNestedQueryShape(string $path, array $value, string $expression, int $depth): void
+    {
+        if ($depth > self::MAX_VARIABLE_DEPTH) {
+            throw self::invalidVariable($expression, $path, 'maximum variable nesting depth exceeded');
+        }
+
+        /** @var mixed $member */
+        foreach ($value as $key => $member) {
+            if ($member === null) {
+                continue;
+            }
+
+            $memberPath = \sprintf('%s[%s]', $path, (string) $key);
+
+            if (\is_string($key)) {
+                self::assertValidVariableUtf8($key, $expression, $memberPath);
+            }
+
+            if (\is_scalar($member)) {
+                if (\is_string($member)) {
+                    self::assertValidVariableUtf8($member, $expression, $memberPath);
+                }
+
+                if (\is_float($member) && !\is_finite($member)) {
+                    throw self::invalidVariable($expression, $memberPath, 'non-finite floats are not supported');
+                }
+
+                continue;
+            }
+
+            if (\is_array($member)) {
+                self::assertNestedQueryShape($memberPath, $member, $expression, $depth + 1);
+                continue;
+            }
+
+            throw self::invalidVariable(
+                $expression,
+                $memberPath,
+                \sprintf('expected scalar or nested array; got %s', \get_debug_type($member))
+            );
+        }
+    }
+
+    /**
      * Validate a referenced variable and return its snapshot.
      *
      * Stringable objects, including stringable members of lists and maps,
@@ -950,15 +1278,26 @@ final class UriTemplate
     /**
      * Determines if an array should be expanded as a map.
      *
+     * An array is a list only when its keys are exactly 0 through n-1 in
+     * ascending insertion order. The keys are compared one by one so the
+     * check stops at the first mismatch and never materializes key arrays
+     * proportional to the member count.
+     *
      * @param array<array-key, mixed> $array
      */
     private static function isAssoc(array $array): bool
     {
-        if ($array === []) {
-            return false;
+        $expected = 0;
+
+        foreach ($array as $key => $member) {
+            if ($key !== $expected) {
+                return true;
+            }
+
+            ++$expected;
         }
 
-        return \array_keys($array) !== \range(0, \count($array) - 1);
+        return false;
     }
 
     private static function prefixValue(string $value, int $length, string $expression, string $name): string

--- a/src/UriTemplate.php
+++ b/src/UriTemplate.php
@@ -99,14 +99,16 @@ final class UriTemplate
      * throughout the expansion and value errors surface in member order.
      * Undefined variables are stored as null.
      *
-     * Values containing no references, floats, or stringable objects, and
-     * values whose shape is certain to be rejected, are shared instead of
-     * being rebuilt: copy-on-write semantics guarantee shared values
-     * cannot change, and sharing avoids materializing structures whose
-     * logical size exceeds their physical size, such as arrays repeating
-     * one shared subtree. Parsed expressions are not retained; expansion
-     * parses each occurrence again, so templates with many distinct
-     * expressions do not allocate storage proportional to their count.
+     * Values containing no references, floats, or stringable objects are
+     * shared instead of being rebuilt: copy-on-write semantics guarantee
+     * shared values cannot change, and sharing avoids materializing
+     * structures whose logical size exceeds their physical size, such as
+     * arrays repeating one shared subtree. Values whose shape is certain
+     * to be rejected are neither shared nor scanned; their rejection is
+     * captured while they are bound and thrown at their formation
+     * position. Parsed expressions are not retained; expansion parses
+     * each occurrence again, so templates with many distinct expressions
+     * do not allocate storage proportional to their count.
      *
      * @param list<string>            $references The distinct expression text, in first-occurrence order
      * @param array<array-key, mixed> $variables
@@ -117,7 +119,7 @@ final class UriTemplate
     {
         /** @var array<array-key, mixed> $values */
         $values = [];
-        /** @var list<array{string, array{value:string, modifier:(''|'*'|':'), position?:int}, string, string, bool}> $order */
+        /** @var list<array{string, array{value:string, modifier:(''|'*'|':'), position?:int}, string, string, bool, \InvalidArgumentException|\RuntimeException|null}> $order */
         $order = [];
 
         foreach ($references as $expression) {
@@ -137,8 +139,10 @@ final class UriTemplate
 
                 /** @var mixed $raw */
                 $raw = $variables[$name];
-                $form = self::valueNeedsForming($raw, 0)
-                    && !self::shapeGuaranteesRejection($varspec, $raw, $parsed['operator']);
+                $rejection = self::shapeGuaranteesRejection($varspec, $raw, $parsed['operator'])
+                    ? self::captureShapeRejection($varspec, $raw, $expression, $parsed['operator'])
+                    : null;
+                $form = $rejection === null && self::valueNeedsForming($raw, 0);
 
                 if ($form) {
                     $membersMayNest = \is_array($raw)
@@ -150,11 +154,15 @@ final class UriTemplate
                 }
 
                 $values[$name] = $raw;
-                $order[] = [$name, $varspec, $expression, $parsed['operator'], $form];
+                $order[] = [$name, $varspec, $expression, $parsed['operator'], $form, $rejection];
             }
         }
 
-        foreach ($order as [$name, $varspec, $expression, $operator, $form]) {
+        foreach ($order as [$name, $varspec, $expression, $operator, $form, $rejection]) {
+            if ($rejection !== null) {
+                throw $rejection;
+            }
+
             if ($form) {
                 $values[$name] = self::normalizeVariableShape($varspec, $values[$name], $expression, $operator);
             } else {
@@ -163,6 +171,32 @@ final class UriTemplate
         }
 
         return $values;
+    }
+
+    /**
+     * Capture the rejection for a value whose shape guarantees one.
+     *
+     * The exception is created while the value is bound, before any
+     * __toString() method runs, so references held by the caller cannot
+     * mutate a rejected value into an accepted shape, and it is thrown
+     * later, at the variable's formation position, so error precedence
+     * does not depend on how a value was classified. Engine failures
+     * surfaced while walking the value are deferred the same way.
+     *
+     * @param array{value:string, modifier:(''|'*'|':'), position?:int} $varspec
+     * @param mixed                                                     $variable
+     *
+     * @return \InvalidArgumentException|\RuntimeException|null
+     */
+    private static function captureShapeRejection(array $varspec, $variable, string $expression, string $operator): ?\Exception
+    {
+        try {
+            self::assertVariableShape($varspec, $variable, $expression, $operator);
+        } catch (\InvalidArgumentException|\RuntimeException $e) {
+            return $e;
+        }
+
+        return null;
     }
 
     /**

--- a/src/UriTemplate.php
+++ b/src/UriTemplate.php
@@ -60,19 +60,20 @@ final class UriTemplate
      */
     public static function expand(string $template, array $variables): string
     {
-        $template = self::prepareTemplate($template);
+        [$template, $references] = self::prepareTemplate($template);
 
-        if (!\str_contains($template, '{')) {
+        if ($references === []) {
             return $template;
         }
 
-        $callback = self::expandMatchCallback($variables);
+        $expressions = self::parseExpressions($references);
+        $values = self::formValues($references, $expressions, $variables);
 
         /** @var string|null */
         $result = \preg_replace_callback(
             '/\{([^\}]+)\}/',
-            static function (array $matches) use ($callback): string {
-                return $callback($matches);
+            static function (array $matches) use ($expressions, $values): string {
+                return self::expandMatch($matches, $expressions, $values);
             },
             $template
         );
@@ -85,23 +86,143 @@ final class UriTemplate
     }
 
     /**
-     * @param array<string, mixed> $variables Variables to use in the template expansion
+     * Parse and validate every expression of the template, in template order.
      *
-     * @return \Closure(array{0: string, 1: string}): string
+     * Expression text such as "0" is a canonical decimal integer string,
+     * which PHP stores under an integer array key.
+     *
+     * @param list<string> $references The expression text of each expression, in template order
+     *
+     * @return array<array-key, array{operator:string, values:array<array{value:string, modifier:(''|'*'|':'), position?:int}>}>
      */
-    private static function expandMatchCallback(array $variables): \Closure
+    private static function parseExpressions(array $references): array
     {
-        return static function (array $matches) use ($variables): string {
-            /** @var array{0: string, 1: string} $matches */
-            return self::expandMatch($matches, $variables);
-        };
+        $expressions = [];
+
+        foreach ($references as $expression) {
+            if (!isset($expressions[$expression])) {
+                $expressions[$expression] = self::parseExpression($expression);
+            }
+        }
+
+        return $expressions;
     }
 
-    private static function prepareTemplate(string $template): string
+    /**
+     * Detach and form every referenced variable value before expansion.
+     *
+     * Spec section 3: each variable's value is formed prior to template
+     * expansion. Definedness is bound and raw values are detached, in
+     * template order, before any __toString() method runs, so an object
+     * converted while values are formed cannot change another referenced
+     * variable through a PHP reference. Stringable objects are then
+     * converted to strings and scalars to their expansion strings, once
+     * per value position, in template order, and string values and map
+     * keys are validated as UTF-8 in the same pass, so a repeated variable
+     * keeps a static value throughout the expansion and value errors
+     * surface in member order. Undefined variables are stored as null.
+     *
+     * @param list<string>                                                                                                      $references  The expression text of each expression, in template order
+     * @param array<array-key, array{operator:string, values:array<array{value:string, modifier:(''|'*'|':'), position?:int}>}> $expressions
+     * @param array<array-key, mixed>                                                                                           $variables
+     *
+     * @return array<array-key, mixed>
+     */
+    private static function formValues(array $references, array $expressions, array $variables): array
+    {
+        /** @var array<array-key, mixed> $detached */
+        $detached = [];
+        /** @var list<array{string, array{value:string, modifier:(''|'*'|':'), position?:int}, string, string}> $order */
+        $order = [];
+
+        foreach ($references as $expression) {
+            foreach ($expressions[$expression]['values'] as $varspec) {
+                $name = $varspec['value'];
+
+                if (\array_key_exists($name, $detached)) {
+                    continue;
+                }
+
+                if (self::isUndefinedVariable($variables, $name)) {
+                    $detached[$name] = null;
+                    continue;
+                }
+
+                $operator = $expressions[$expression]['operator'];
+                /** @var mixed $raw */
+                $raw = $variables[$name];
+                $membersMayNest = \is_array($raw)
+                    && $varspec['modifier'] === '*'
+                    && ($operator === '?' || $operator === '&')
+                    && self::isAssoc($raw);
+
+                $detached[$name] = self::detachValue($raw, $membersMayNest, 0);
+                $order[] = [$name, $varspec, $expression, $operator];
+            }
+        }
+
+        $values = $detached;
+
+        foreach ($order as [$name, $varspec, $expression, $operator]) {
+            $values[$name] = self::normalizeVariableShape($varspec, $detached[$name], $expression, $operator);
+        }
+
+        return $values;
+    }
+
+    /**
+     * Detach a raw variable value from the caller's variables array.
+     *
+     * Admissible arrays are rebuilt so that PHP references held by the
+     * caller cannot change the value after it has been read, and scalars
+     * are copied. Object handles are kept as they are; stringable objects
+     * are resolved later, while values are formed. Array members outside a
+     * nested query array, and levels deeper than the nesting limit, are
+     * kept as they are: shape validation rejects them by type or depth
+     * without reading their contents, and rebuilding them could
+     * materialize a copy-on-write shared array graph of unbounded logical
+     * size.
+     *
+     * @param mixed $value
+     *
+     * @return mixed
+     */
+    private static function detachValue($value, bool $membersMayNest, int $depth)
+    {
+        if (!\is_array($value) || $depth > self::MAX_VARIABLE_DEPTH) {
+            return $value;
+        }
+
+        /** @var array<array-key, mixed> $detached */
+        $detached = [];
+
+        /** @var mixed $member */
+        foreach ($value as $key => $member) {
+            $detached[$key] = \is_array($member) && !$membersMayNest
+                ? $member
+                : self::detachValue($member, true, $depth + 1);
+        }
+
+        return $detached;
+    }
+
+    /**
+     * Validate and encode the template's literal text and collect its
+     * distinct expressions in first-occurrence order.
+     *
+     * Only distinct expression text is collected, so a template that
+     * repeats an expression many times does not allocate storage
+     * proportional to the number of occurrences.
+     *
+     * @return array{string, list<string>}
+     */
+    private static function prepareTemplate(string $template): array
     {
         $length = \strlen($template);
         $prepared = '';
         $literalStart = 0;
+        $references = [];
+        $seen = [];
 
         for ($offset = 0; $offset < $length; ++$offset) {
             $char = $template[$offset];
@@ -128,6 +249,11 @@ final class UriTemplate
                     throw self::invalidTemplate($offset, 'nested expressions are not allowed');
                 }
 
+                if (!isset($seen[$expression])) {
+                    $seen[$expression] = true;
+                    $references[] = $expression;
+                }
+
                 $prepared .= \substr($template, $offset, $end - $offset + 1);
                 $offset = $end;
                 $literalStart = $end + 1;
@@ -140,7 +266,7 @@ final class UriTemplate
             }
         }
 
-        return $prepared.self::encodeLiteralSegment(\substr($template, $literalStart), $literalStart);
+        return [$prepared.self::encodeLiteralSegment(\substr($template, $literalStart), $literalStart), $references];
     }
 
     private static function invalidTemplate(int $offset, string $message): \InvalidArgumentException
@@ -155,15 +281,16 @@ final class UriTemplate
     /**
      * Process an expansion
      *
-     * @param array<string, mixed>        $variables Variables to use in the template expansion
-     * @param array{0: string, 1: string} $matches   Matches met in the preg_replace_callback
+     * @param array{0: string, 1: string}                                                                                       $matches     Matches met in the preg_replace_callback
+     * @param array<array-key, array{operator:string, values:array<array{value:string, modifier:(''|'*'|':'), position?:int}>}> $expressions Parsed expressions of the template
+     * @param array<array-key, mixed>                                                                                           $values      Variable values formed before the expansion began
      *
      * @return string Returns the replacement string
      */
-    private static function expandMatch(array $matches, array $variables): string
+    private static function expandMatch(array $matches, array $expressions, array $values): string
     {
         $replacements = [];
-        $parsed = self::parseExpression($matches[1]);
+        $parsed = $expressions[$matches[1]];
         $prefix = self::OPERATOR_HASH[$parsed['operator']]['prefix'];
         $joiner = self::OPERATOR_HASH[$parsed['operator']]['joiner'];
         $useQuery = self::OPERATOR_HASH[$parsed['operator']]['query'];
@@ -172,13 +299,18 @@ final class UriTemplate
         $hasDefinedVariable = false;
 
         foreach ($parsed['values'] as $value) {
-            if (self::isUndefinedVariable($variables, $value['value'])) {
+            if ($values[$value['value']] === null) {
                 continue;
             }
 
-            $variable = $variables[$value['value']];
+            /** @var mixed $variable */
+            $variable = $values[$value['value']];
 
-            self::assertVariableShape($value, $variable, $matches[1], $parsed['operator']);
+            // Varspec-specific checks, such as the prefix-on-composite
+            // rule, run on every occurrence against the formed value, so an
+            // occurrence with an inapplicable modifier throws no matter
+            // where it appears in the template.
+            self::normalizeVariableShape($value, $variable, $matches[1], $parsed['operator']);
 
             $actuallyUseQuery = $useQuery;
             $expanded = '';
@@ -220,10 +352,11 @@ final class UriTemplate
                         if ($isAssoc) {
                             if ($isNestedArray) {
                                 // Nested arrays must allow for deeply nested structures.
-                                // Float members are stringified first because
-                                // http_build_query's own float conversion
-                                // honors LC_NUMERIC before PHP 8.0.
-                                $var = \http_build_query([$rawKey => self::stringifyNestedFloats($var)], '', '&', \PHP_QUERY_RFC3986);
+                                // Members were converted to their expansion
+                                // strings while values were formed, so
+                                // http_build_query's own locale-sensitive
+                                // float conversion is never used.
+                                $var = \http_build_query([$rawKey => $var], '', '&', \PHP_QUERY_RFC3986);
                                 if ($var === '') {
                                     continue;
                                 }
@@ -359,28 +492,6 @@ final class UriTemplate
         }
 
         return $string;
-    }
-
-    /**
-     * Stringify float members of a nested query array so http_build_query
-     * does not apply its own locale-sensitive float conversion on PHP 7.4.
-     *
-     * @param array<array-key, mixed> $value
-     *
-     * @return array<array-key, mixed>
-     */
-    private static function stringifyNestedFloats(array $value): array
-    {
-        /** @var mixed $member */
-        foreach ($value as $key => $member) {
-            if (\is_float($member)) {
-                $value[$key] = self::stringifyFloat($member);
-            } elseif (\is_array($member)) {
-                $value[$key] = self::stringifyNestedFloats($member);
-            }
-        }
-
-        return $value;
     }
 
     /**
@@ -566,17 +677,29 @@ final class UriTemplate
     }
 
     /**
+     * Validate a referenced variable and return its snapshot.
+     *
+     * Stringable objects, including stringable members of lists and maps,
+     * are converted to strings exactly once, at validation time, so a
+     * repeated variable keeps a static value throughout the expansion and a
+     * mutating __toString() cannot bypass validation. Later occurrences of
+     * the same variable revalidate the returned snapshot against their own
+     * varspec and discard the result, so varspec-specific checks such as
+     * the prefix-on-composite rule run on every occurrence.
+     *
      * @param array{value:string, modifier:(''|'*'|':'), position?:int} $varspec
      * @param mixed                                                     $variable
+     *
+     * @return mixed
      */
-    private static function assertVariableShape(array $varspec, $variable, string $expression, string $operator): void
+    private static function normalizeVariableShape(array $varspec, $variable, string $expression, string $operator)
     {
         if (self::isScalarLike($variable)) {
             if (\is_float($variable) && !\is_finite($variable)) {
                 throw self::invalidVariable($expression, $varspec['value'], 'non-finite floats are not supported');
             }
 
-            return;
+            return self::formScalarLike($variable, $expression, $varspec['value']);
         }
 
         if (!\is_array($variable)) {
@@ -598,17 +721,13 @@ final class UriTemplate
             );
         }
 
-        $isAssoc = self::isAssoc($variable);
-
-        if (!$isAssoc) {
-            self::assertListShape($varspec['value'], $variable, $expression);
-
-            return;
+        if (!self::isAssoc($variable)) {
+            return self::normalizeListShape($varspec['value'], $variable, $expression);
         }
 
         $allowNestedArrays = $varspec['modifier'] === '*' && ($operator === '?' || $operator === '&');
 
-        self::assertMapShape($varspec['value'], $variable, $expression, $allowNestedArrays, 0);
+        return self::normalizeMapShape($varspec['value'], $variable, $expression, $allowNestedArrays, 0);
     }
 
     /**
@@ -620,10 +739,55 @@ final class UriTemplate
     }
 
     /**
-     * @param array<array-key, mixed> $value
+     * Form a null, scalar, or stringable value while values are formed.
+     *
+     * Stringable objects are resolved to strings once per value position
+     * here, so their __toString() methods are never called again during
+     * expansion, and scalars are converted to their expansion strings, so
+     * repeated occurrences render identically even when a __toString()
+     * method changes the float precision or the locale mid-expansion.
+     * String values are validated as UTF-8 in the same pass, per spec
+     * section 1.6, so all value errors surface in member order while
+     * values are formed. Null is returned unchanged because it marks an
+     * undefined member.
+     *
+     * @param mixed $value
      */
-    private static function assertListShape(string $path, array $value, string $expression): void
+    private static function formScalarLike($value, string $expression, string $path): ?string
     {
+        if ($value === null) {
+            return null;
+        }
+
+        if (\is_object($value) && \method_exists($value, '__toString')) {
+            $value = (string) $value;
+        }
+
+        if (\is_string($value)) {
+            self::assertValidVariableUtf8($value, $expression, $path);
+
+            return $value;
+        }
+
+        return self::stringifyValue($value);
+    }
+
+    /**
+     * Validate a list variable and snapshot its members.
+     *
+     * Rebuilding the list resolves stringable members once per value
+     * position and breaks PHP references held by the caller's array, so
+     * members mutated after the snapshot is taken cannot change the
+     * expansion.
+     *
+     * @param array<array-key, mixed> $value
+     *
+     * @return array<array-key, mixed>
+     */
+    private static function normalizeListShape(string $path, array $value, string $expression): array
+    {
+        $normalized = [];
+
         foreach ($value as $index => $member) {
             $memberPath = \sprintf('%s[%d]', $path, $index);
 
@@ -632,6 +796,7 @@ final class UriTemplate
                     throw self::invalidVariable($expression, $memberPath, 'non-finite floats are not supported');
                 }
 
+                $normalized[] = self::formScalarLike($member, $expression, $memberPath);
                 continue;
             }
 
@@ -641,35 +806,65 @@ final class UriTemplate
                 \sprintf('expected scalar or stringable object; got %s', \get_debug_type($member))
             );
         }
+
+        return $normalized;
     }
 
     /**
+     * Validate a map variable and snapshot its members.
+     *
+     * Rebuilding the map resolves stringable members once per value
+     * position and breaks PHP references held by the caller's array, so
+     * members mutated after the snapshot is taken cannot change the
+     * expansion.
+     *
      * @param array<array-key, mixed> $value
+     *
+     * @return array<array-key, mixed>
      */
-    private static function assertMapShape(
+    private static function normalizeMapShape(
         string $path,
         array $value,
         string $expression,
         bool $allowNestedArrays,
         int $depth
-    ): void {
+    ): array {
         if ($depth > self::MAX_VARIABLE_DEPTH) {
             throw self::invalidVariable($expression, $path, 'maximum variable nesting depth exceeded');
         }
 
+        $normalized = [];
+
         foreach ($value as $key => $member) {
+            if ($member === null) {
+                // Spec section 2.4.2: only pairs with defined values are
+                // present in the expansion, so null members are omitted
+                // before their keys are validated, matching the handling
+                // of null members in nested query arrays.
+                $normalized[$key] = null;
+                continue;
+            }
+
             $memberPath = \sprintf('%s[%s]', $path, (string) $key);
 
-            if ($member === null || self::isScalarLike($member)) {
+            if (\is_string($key)) {
+                // Spec section 3.2.1: pair names are encoded like simple
+                // string values, so keys are validated as UTF-8 while
+                // values are formed, before their members.
+                self::assertValidVariableUtf8($key, $expression, $memberPath);
+            }
+
+            if (self::isScalarLike($member)) {
                 if (\is_float($member) && !\is_finite($member)) {
                     throw self::invalidVariable($expression, $memberPath, 'non-finite floats are not supported');
                 }
 
+                $normalized[$key] = self::formScalarLike($member, $expression, $memberPath);
                 continue;
             }
 
             if (\is_array($member) && $allowNestedArrays) {
-                self::assertNestedQueryShape($memberPath, $member, $expression, $depth + 1);
+                $normalized[$key] = self::normalizeNestedQueryShape($memberPath, $member, $expression, $depth + 1);
                 continue;
             }
 
@@ -679,16 +874,29 @@ final class UriTemplate
                 \sprintf('expected scalar%s; got %s', $allowNestedArrays ? ', stringable object, or nested array' : ' or stringable object', \get_debug_type($member))
             );
         }
+
+        return $normalized;
     }
 
     /**
+     * Validate a nested query array and snapshot its members.
+     *
+     * Nested query arrays accept only scalar leaves, so there are no
+     * stringable objects to resolve, but rebuilding the array breaks PHP
+     * references held by the caller's array, so members mutated after the
+     * snapshot is taken cannot change the expansion.
+     *
      * @param array<array-key, mixed> $value
+     *
+     * @return array<array-key, mixed>
      */
-    private static function assertNestedQueryShape(string $path, array $value, string $expression, int $depth): void
+    private static function normalizeNestedQueryShape(string $path, array $value, string $expression, int $depth): array
     {
         if ($depth > self::MAX_VARIABLE_DEPTH) {
             throw self::invalidVariable($expression, $path, 'maximum variable nesting depth exceeded');
         }
+
+        $normalized = [];
 
         foreach ($value as $key => $member) {
             if ($member === null) {
@@ -696,6 +904,7 @@ final class UriTemplate
                 // values are present in the expansion, so null members are
                 // omitted before their keys are validated, matching the
                 // handling of null members in top-level maps.
+                $normalized[$key] = null;
                 continue;
             }
 
@@ -714,11 +923,17 @@ final class UriTemplate
                     throw self::invalidVariable($expression, $memberPath, 'non-finite floats are not supported');
                 }
 
+                // Scalars are converted to their expansion strings while
+                // values are formed, so http_build_query never applies its
+                // own locale-sensitive float conversion and repeated
+                // occurrences render identically even when the float
+                // precision changes mid-expansion.
+                $normalized[$key] = self::stringifyValue($member);
                 continue;
             }
 
             if (\is_array($member)) {
-                self::assertNestedQueryShape($memberPath, $member, $expression, $depth + 1);
+                $normalized[$key] = self::normalizeNestedQueryShape($memberPath, $member, $expression, $depth + 1);
                 continue;
             }
 
@@ -728,6 +943,8 @@ final class UriTemplate
                 \sprintf('expected scalar or nested array; got %s', \get_debug_type($member))
             );
         }
+
+        return $normalized;
     }
 
     /**

--- a/tests/UriTemplateTest.php
+++ b/tests/UriTemplateTest.php
@@ -1071,6 +1071,35 @@ final class UriTemplateTest extends TestCase
         self::assertSame(\str_repeat('y', 200000), UriTemplate::expand($template, ['x' => 'y']));
     }
 
+    public function testExpandsManyDistinctExpressionsWithoutRetainingParses(): void
+    {
+        $template = '';
+        for ($i = 0; $i < 20000; ++$i) {
+            $template .= '{v'.$i.'}';
+        }
+
+        self::assertSame('', UriTemplate::expand($template, []));
+    }
+
+    public function testSharesNestedQueryStructuresThatCannotChange(): void
+    {
+        $shared = ['v', 'w'];
+
+        self::assertSame(
+            '?a%5B0%5D%5B0%5D=v&a%5B0%5D%5B1%5D=w&a%5B1%5D%5B0%5D=v&a%5B1%5D%5B1%5D=w',
+            UriTemplate::expand('{?x*}', ['x' => ['a' => [$shared, $shared]]])
+        );
+    }
+
+    public function testRejectsReferenceCyclesWithoutMaterializingThem(): void
+    {
+        $cycle = [];
+        $cycle[0] = &$cycle;
+        $cycle[1] = &$cycle;
+
+        $this->assertInvalidTemplate('{?x*}', ['x' => ['k' => $cycle]]);
+    }
+
     /**
      * @return array<string,array{0:mixed}>
      */

--- a/tests/UriTemplateTest.php
+++ b/tests/UriTemplateTest.php
@@ -778,6 +778,7 @@ final class UriTemplateTest extends TestCase
             'stringable object' => ['{x}', ['x' => new StringableValue('ok')], 'ok'],
             'stringable object in list' => ['{x}', ['x' => [new StringableValue('ok')]], 'ok'],
             'stringable object in map' => ['{?x*}', ['x' => ['a' => new StringableValue('ok')]], '?a=ok'],
+            'empty stringable in exploded path map' => ['{/x*}', ['x' => ['name' => new StringableValue('')]], '/name'],
             'list' => ['{/x*}', ['x' => ['red', 'green']], '/red/green'],
             'map' => ['{?x*}', ['x' => ['a' => 'b']], '?a=b'],
             'nested exploded map extension' => ['{?x*}', ['x' => ['a' => ['b' => 'c']]], '?a%5Bb%5D=c'],
@@ -933,6 +934,215 @@ final class UriTemplateTest extends TestCase
     public function testIgnoresUnusedInvalidVariableShapes(): void
     {
         self::assertSame('ok', UriTemplate::expand('{x}', ['x' => 'ok', 'unused' => new \stdClass()]));
+    }
+
+    /**
+     * @return array<string,array{0:string, 1:string}>
+     */
+    public static function repeatedStringableProvider(): array
+    {
+        return [
+            'same expression' => ['{x,x}', '1,1'],
+            'separate expressions' => ['{x}-{x}', '1-1'],
+            'mixed operators' => ['{x}{?x}', '1?x=1'],
+        ];
+    }
+
+    /**
+     * @dataProvider repeatedStringableProvider
+     */
+    public function testReusesStringableValuesForEveryOccurrence(string $template, string $expansion): void
+    {
+        self::assertSame($expansion, UriTemplate::expand($template, ['x' => new CountingStringable()]));
+    }
+
+    public function testCallsToStringExactlyOncePerExpansion(): void
+    {
+        $counter = new CountingStringable();
+
+        self::assertSame('11?x=1', UriTemplate::expand('{x}{x}{?x}', ['x' => $counter]));
+        self::assertSame(1, $counter->calls);
+
+        self::assertSame('22?x=2', UriTemplate::expand('{x}{x}{?x}', ['x' => $counter]));
+        self::assertSame(2, $counter->calls);
+    }
+
+    /**
+     * @return array<string,array{0:string}>
+     */
+    public static function definednessTemplateProvider(): array
+    {
+        return [
+            'undefined referenced first' => ['{x}{y}{x}'],
+            'undefined referenced last' => ['{y}{x}'],
+        ];
+    }
+
+    /**
+     * @dataProvider definednessTemplateProvider
+     */
+    public function testBindsDefinednessBeforeValuesAreFormed(string $template): void
+    {
+        $slot = null;
+        $mutator = new SideEffectStringable('v', static function () use (&$slot): void {
+            $slot = 'now defined';
+        });
+
+        self::assertSame('v', UriTemplate::expand($template, ['x' => &$slot, 'y' => $mutator]));
+    }
+
+    public function testDetachesValuesBeforeValuesAreFormed(): void
+    {
+        $slot = 'before';
+        $mutator = new SideEffectStringable('first', static function () use (&$slot): void {
+            $slot = 'after';
+        });
+        $variables = ['a' => $mutator, 'b' => &$slot];
+
+        self::assertSame('first-before', UriTemplate::expand('{a}-{b}', $variables));
+
+        $slot = 'before';
+
+        self::assertSame('before-first-before', UriTemplate::expand('{b}-{a}-{b}', $variables));
+    }
+
+    public function testFormsFloatsBeforeExpansionBegins(): void
+    {
+        $precision = (string) \ini_get('precision');
+        $mutator = new SideEffectStringable('M', static function (): void {
+            \ini_set('precision', '3');
+        });
+
+        try {
+            \ini_set('precision', '14');
+
+            self::assertSame(
+                '1.23456789-M-1.23456789',
+                UriTemplate::expand('{x}-{m}-{x}', ['x' => 1.23456789, 'm' => $mutator])
+            );
+
+            \ini_set('precision', '14');
+
+            self::assertSame(
+                '?a%5Bb%5D=1.23456789M&a%5Bb%5D=1.23456789',
+                UriTemplate::expand('{?q*}{m}{&q*}', ['q' => ['a' => ['b' => 1.23456789]], 'm' => $mutator])
+            );
+        } finally {
+            \ini_set('precision', $precision);
+        }
+    }
+
+    public function testValidatesEveryExpressionBeforeValuesAreFormed(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('unsupported operator');
+
+        UriTemplate::expand('{x}{!y}', ['x' => new \stdClass()]);
+    }
+
+    public function testValidatesStringValuesWhileValuesAreFormed(): void
+    {
+        $throwing = new SideEffectStringable('v', static function (): void {
+            throw new \DomainException('should not be reached');
+        });
+
+        try {
+            UriTemplate::expand('{a}{b}', ['a' => "\xC3\x28", 'b' => $throwing]);
+            self::fail('Expected an InvalidArgumentException.');
+        } catch (\InvalidArgumentException $e) {
+            self::assertStringContainsString('must be valid UTF-8', $e->getMessage());
+        }
+    }
+
+    public function testRejectsSharedArrayGraphMembersWithoutMaterializingThem(): void
+    {
+        $graph = ['a', 'b'];
+        for ($i = 0; $i < 21; ++$i) {
+            $graph = [$graph, $graph];
+        }
+
+        $this->assertInvalidTemplate('{x}', ['x' => $graph]);
+    }
+
+    public function testExpandsRepeatedExpressionsWithoutPerOccurrenceStorage(): void
+    {
+        $template = \str_repeat('{x}', 200000);
+
+        self::assertSame(\str_repeat('y', 200000), UriTemplate::expand($template, ['x' => 'y']));
+    }
+
+    /**
+     * @return array<string,array{0:mixed}>
+     */
+    public static function detachedMutationProvider(): array
+    {
+        return [
+            'mutation to infinity' => [\INF],
+            'mutation to array' => [[]],
+        ];
+    }
+
+    /**
+     * @dataProvider detachedMutationProvider
+     *
+     * @param mixed $mutation
+     */
+    public function testListMembersAreDetachedBeforeValuesAreFormed($mutation): void
+    {
+        $slot = 'ok';
+        $mutator = new SideEffectStringable('first', static function () use (&$slot, $mutation): void {
+            $slot = $mutation;
+        });
+
+        self::assertSame('first,ok', UriTemplate::expand('{x}', ['x' => [$mutator, &$slot]]));
+    }
+
+    /**
+     * @return array<string,array{0:string, 1:array<string,mixed>}>
+     */
+    public static function repeatedVarspecPrefixOnCompositeProvider(): array
+    {
+        return [
+            'prefix before explode' => ['{x:1,x*}', ['x' => ['red', 'green']]],
+            'explode before prefix' => ['{x*,x:1}', ['x' => ['red', 'green']]],
+            'all null list prefix before simple' => ['{l:1}{l}', ['l' => [null]]],
+            'all null list prefix after simple' => ['{l}{l:1}', ['l' => [null]]],
+        ];
+    }
+
+    /**
+     * @dataProvider repeatedVarspecPrefixOnCompositeProvider
+     *
+     * @param array<string,mixed> $variables
+     */
+    public function testRejectsPrefixModifiersOnRepeatedCompositeOccurrences(string $template, array $variables): void
+    {
+        $this->assertInvalidTemplate($template, $variables);
+    }
+
+    public function testNestedQueryReferencesAreDetachedBeforeValuesAreFormed(): void
+    {
+        $leaf = 'safe';
+        $mutator = new SideEffectStringable('v', static function () use (&$leaf): void {
+            $leaf = 'evil';
+        });
+        $variables = ['m' => ['a' => ['b' => &$leaf]], 'x' => $mutator];
+
+        self::assertSame('?a%5Bb%5D=safev&a%5Bb%5D=safe', UriTemplate::expand('{?m*}{x}{&m*}', $variables));
+
+        $leaf = 'safe';
+
+        self::assertSame('v?a%5Bb%5D=safe', UriTemplate::expand('{x}{?m*}', $variables));
+    }
+
+    public function testNestedQueryReferenceMutationToInvalidValuesHasNoEffect(): void
+    {
+        $leaf = 'safe';
+        $mutator = new SideEffectStringable('v', static function () use (&$leaf): void {
+            $leaf = \INF;
+        });
+
+        self::assertSame('v?a%5Bb%5D=safe', UriTemplate::expand('{x}{?m*}', ['m' => ['a' => ['b' => &$leaf]], 'x' => $mutator]));
     }
 
     public function testRejectsRecursiveArrayVariables(): void
@@ -1337,6 +1547,36 @@ final class StringableValue
 
     public function __toString(): string
     {
+        return $this->value;
+    }
+}
+
+final class CountingStringable
+{
+    public int $calls = 0;
+
+    public function __toString(): string
+    {
+        return (string) ++$this->calls;
+    }
+}
+
+final class SideEffectStringable
+{
+    private string $value;
+
+    private \Closure $sideEffect;
+
+    public function __construct(string $value, \Closure $sideEffect)
+    {
+        $this->value = $value;
+        $this->sideEffect = $sideEffect;
+    }
+
+    public function __toString(): string
+    {
+        ($this->sideEffect)();
+
         return $this->value;
     }
 }

--- a/tests/UriTemplateTest.php
+++ b/tests/UriTemplateTest.php
@@ -1054,14 +1054,40 @@ final class UriTemplateTest extends TestCase
         }
     }
 
+    public function testBindsRejectionsBeforeValuesAreFormed(): void
+    {
+        $member = new \stdClass();
+        $mutator = new SideEffectStringable('a', static function () use (&$member): void {
+            $member = 'now-valid';
+        });
+
+        try {
+            UriTemplate::expand('{a}{b}{b}', ['a' => $mutator, 'b' => [&$member]]);
+            self::fail('Expected an InvalidArgumentException.');
+        } catch (\InvalidArgumentException $e) {
+            self::assertStringContainsString('expected scalar or stringable object; got stdClass', $e->getMessage());
+        }
+
+        self::assertSame('now-valid', $member);
+    }
+
     public function testRejectsSharedArrayGraphMembersWithoutMaterializingThem(): void
     {
         $graph = ['a', 'b'];
-        for ($i = 0; $i < 21; ++$i) {
+        for ($i = 0; $i < 25; ++$i) {
             $graph = [$graph, $graph];
         }
 
-        $this->assertInvalidTemplate('{x}', ['x' => $graph]);
+        $start = \microtime(true);
+
+        try {
+            UriTemplate::expand('{x}', ['x' => $graph]);
+            self::fail('Expected an InvalidArgumentException.');
+        } catch (\InvalidArgumentException $e) {
+            self::assertStringContainsString('expected scalar or stringable object; got array', $e->getMessage());
+        }
+
+        self::assertLessThan(1.0, \microtime(true) - $start);
     }
 
     public function testExpandsRepeatedExpressionsWithoutPerOccurrenceStorage(): void


### PR DESCRIPTION
RFC 6570 section 3 requires each variable value to be formed prior to template expansion and section 3.2.1 requires a repeated variable to keep a static value throughout the expansion. Values were previously snapshotted lazily inside the replacement callback, so a stringable object converted early in the template could still mutate a later referenced variable through a PHP reference, and floats stayed raw in the snapshot and were re-stringified at every occurrence, so a __toString() method that changes the float precision could render the same variable differently within one URI. Template syntax is now validated for every expression up front, definedness is bound and raw values are detached before any __toString() method runs, and stringable objects and scalars are converted to their expansion strings exactly once, in template order, so expansion reads only immutable formed values.