### PR TITLE
Document integer keys for numeric variable names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 - Fixed path-style parameter explode rendering empty members as `name=` instead of bare `name`
 - Fixed map keys not using the operator's allow set under reserved and fragment expansion
 - Fixed map explode rendering empty members as `name=` instead of bare `name` for unnamed operators
+- Fixed the documented variables array type rejecting integer keys for numeric variable names
 - Fixed all-null maps throwing with prefix modifiers instead of being skipped as undefined
 - Fixed prefix modifiers splitting Unicode code points encoded as multiple pct-encoded triplets
 - Fixed path-style expansion of composites rendering bare `name` instead of `name=` for empty joined members

--- a/docs/input-contract.md
+++ b/docs/input-contract.md
@@ -24,6 +24,15 @@ UriTemplate::expand('/users/{user.id}', [
 ]);
 ```
 
+RFC 6570 variable names may consist entirely of digits, such as `{0}`. PHP
+coerces array keys that are canonical decimal integer strings to integers, so
+`['0' => 'x']` and `[0 => 'x']` are the same key. An all-numeric variable name
+is matched against that integer key and expands normally. A name that is not
+a canonical decimal integer string, such as `{01}`, is not coerced; it must
+appear under the exact string key `'01'`. Coercion follows the platform
+integer range: a numeric name beyond `PHP_INT_MAX`, such as `{2147483648}` on
+32-bit PHP, stays a string key and must match exactly.
+
 ## Values
 
 Supported variable values are:

--- a/src/UriTemplate.php
+++ b/src/UriTemplate.php
@@ -53,7 +53,7 @@ final class UriTemplate
     }
 
     /**
-     * @param array<string, mixed> $variables Variables to use in the template expansion
+     * @param array<array-key, mixed> $variables Variables to use in the template expansion
      *
      * @throws \InvalidArgumentException When the template syntax or referenced variable shape is invalid
      * @throws \RuntimeException
@@ -791,7 +791,7 @@ final class UriTemplate
      * variables are ignored by the expansion process, so they are skipped
      * before varspec shape validation.
      *
-     * @param array<string, mixed> $variables
+     * @param array<array-key, mixed> $variables
      */
     private static function isUndefinedVariable(array $variables, string $name): bool
     {

--- a/tests/UriTemplateTest.php
+++ b/tests/UriTemplateTest.php
@@ -409,6 +409,30 @@ final class UriTemplateTest extends TestCase
         $this->assertInvalidTemplate($template);
     }
 
+    /**
+     * @return array<string,array{0:string, 1:array<array-key,mixed>, 2:string}>
+     */
+    public static function allNumericVariableNameProvider(): array
+    {
+        return [
+            'integer key' => ['{0}', [0 => 'x'], 'x'],
+            'non-canonical string key' => ['{01}', ['01' => 'x'], 'x'],
+            'largest integer key' => ['{'.\PHP_INT_MAX.'}', [\PHP_INT_MAX => 'x'], 'x'],
+            'beyond the integer range' => ['{'.\PHP_INT_MAX.'0}', [\PHP_INT_MAX.'0' => 'x'], 'x'],
+            'multiple names' => ['{?0,1}', [0 => 'a', 1 => 'b'], '?0=a&1=b'],
+        ];
+    }
+
+    /**
+     * @dataProvider allNumericVariableNameProvider
+     *
+     * @param array<array-key,mixed> $variables
+     */
+    public function testExpandsAllNumericVariableNames(string $template, array $variables, string $expansion): void
+    {
+        self::assertSame($expansion, UriTemplate::expand($template, $variables));
+    }
+
     public function testReportsEngineFailuresOnLongVariableNamesAsRuntimeException(): void
     {
         // Spec section 2.3 places no length limit on variable names, so a


### PR DESCRIPTION
All-numeric RFC 6570 variable names such as {0} are valid and already expand correctly at runtime, but PHP coerces their canonical string keys to integers, so the documented array<string, mixed> type for the variables argument rejected those integer keys under PHPStan level 9. This widens the variables type to array<array-key, mixed> across the public and internal signatures, documents how PHP coerces canonical integer-string keys in the input contract, and adds coverage for expanding all-numeric variable names. This builds on #110 and should be merged after it.