### PR TITLE
Escape C1 controls in URI template diagnostics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,9 @@
 - Handle `preg_*` engine failures: when the result is used as data, test for
   `false` or `null` and throw a `\RuntimeException` including
   `preg_last_error_msg()`; boolean validation guards must compare strictly, such
-  as `=== 1`, so an engine failure can only ever fail closed.
+  as `=== 1`, so an engine failure can only ever fail closed. Diagnostic
+  escaping is the narrow exception: use a deterministic bytewise fallback rather
+  than throwing, so it cannot obscure the original exception.
 - Anchor validation patterns to the true end of input with the `D` modifier or
   `\z`; a bare `$` accepts a trailing newline.
 - Never embed raw control bytes in exception messages and other diagnostics;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,9 +45,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 - Fixed float values expanding with the locale decimal separator on PHP versions before 8.0
 - Fixed PCRE engine failures on very long variable names being reported as invalid template syntax
 - Fixed invalid UTF-8 errors for list and map members not reporting the member path
-- Fixed exception messages embedding raw invalid UTF-8 bytes from map keys
-- Fixed exception messages embedding raw invalid UTF-8 bytes from expression text
-- Fixed exception messages embedding raw ASCII control bytes from expression text and map keys
+- Fixed exception messages embedding raw controls or malformed UTF-8 from expressions and map keys
 - Fixed invalid UTF-8 in literal text reported at the segment offset, not the first invalid byte
 - Fixed PCRE engine failures during literal text validation being reported as invalid UTF-8
 - Fixed PCRE engine failures during variable UTF-8 validation not being reported as runtime errors

--- a/docs/input-contract.md
+++ b/docs/input-contract.md
@@ -194,9 +194,11 @@ operators, invalid variable names, invalid modifiers, invalid literal text, and
 unsupported shapes for variables referenced by the template.
 
 Errors for invalid list and map members identify the member by path, such as
-`x[1]` or `filter[author][name]`. In member paths and expression text, ASCII
-control bytes are escaped as `\xHH`; when the text contains invalid byte
-sequences, all bytes outside printable ASCII are escaped.
+`x[1]` or `filter[author][name]`. Member paths and expression text use
+diagnostic escaping. C0, DEL, and C1 controls are rendered as `\xHH`. If
+UTF-8-aware diagnostic escaping fails, every byte outside printable ASCII is
+rendered in the same form. The result is diagnostic text, not a reversible
+encoding.
 
 `RuntimeException` is thrown when the PCRE engine fails while processing a
 template, for example when an extremely long variable name or very large

--- a/src/UriTemplate.php
+++ b/src/UriTemplate.php
@@ -773,11 +773,7 @@ final class UriTemplate
 
     private static function invalidExpression(string $expression, string $message): \InvalidArgumentException
     {
-        return new \InvalidArgumentException(\sprintf(
-            'Invalid URI template expression "{%s}": %s.',
-            self::escapeInvalidUtf8ForMessage($expression),
-            self::escapeInvalidUtf8ForMessage($message)
-        ));
+        return new \InvalidArgumentException(\sprintf('Invalid URI template expression {%s}: %s.', self::escapeDiagnosticValue($expression), self::escapeDiagnosticValue($message)));
     }
 
     /**
@@ -823,33 +819,48 @@ final class UriTemplate
 
     private static function invalidVariable(string $expression, string $path, string $message): \InvalidArgumentException
     {
-        return new \InvalidArgumentException(\sprintf(
-            'Invalid URI template variable "%s" in "{%s}": %s.',
-            self::escapeInvalidUtf8ForMessage($path),
-            self::escapeInvalidUtf8ForMessage($expression),
-            $message
-        ));
+        return new \InvalidArgumentException(\sprintf('Invalid URI template variable "%s" in {%s}: %s.', self::escapeDiagnosticValue($path), self::escapeDiagnosticValue($expression), $message));
     }
 
     /**
      * Escape unsafe diagnostic text before embedding it in exception messages.
      *
-     * ASCII control bytes are always escaped as \xHH. Text that is not valid
-     * UTF-8 additionally has all bytes outside printable ASCII escaped.
+     * C0, DEL, and C1 controls are rendered as \xHH. If UTF-8-aware diagnostic
+     * escaping fails, every byte outside printable ASCII is rendered in the
+     * same form. The result is diagnostic text, not a reversible encoding.
      */
-    private static function escapeInvalidUtf8ForMessage(string $value): string
+    private static function escapeDiagnosticValue(string $value): string
     {
-        $isValidUtf8 = \preg_match('//u', $value) === 1;
-        $sanitized = '';
+        $escaped = \preg_replace_callback(
+            '/[\x{0000}-\x{001F}\x{007F}-\x{009F}]/u',
+            static function (array $matches): string {
+                $character = $matches[0];
+                $codePoint = \strlen($character) === 1 ? \ord($character) : \ord($character[1]);
+
+                return \sprintf('\\x%02X', $codePoint);
+            },
+            $value
+        );
+
+        return $escaped ?? self::escapeDiagnosticBytes($value);
+    }
+
+    private static function escapeDiagnosticBytes(string $value): string
+    {
+        $escaped = '';
 
         for ($offset = 0, $length = \strlen($value); $offset < $length; ++$offset) {
-            $ord = \ord($value[$offset]);
-            $isSafeByte = $ord >= 0x20 && $ord !== 0x7F && ($isValidUtf8 || $ord <= 0x7E);
+            $byte = \ord($value[$offset]);
+            if ($byte >= 0x20 && $byte <= 0x7E) {
+                $escaped .= $value[$offset];
 
-            $sanitized .= $isSafeByte ? $value[$offset] : \sprintf('\x%02X', $ord);
+                continue;
+            }
+
+            $escaped .= \sprintf('\\x%02X', $byte);
         }
 
-        return $sanitized;
+        return $escaped;
     }
 
     /**

--- a/tests/UriTemplateTest.php
+++ b/tests/UriTemplateTest.php
@@ -637,9 +637,12 @@ final class UriTemplateTest extends TestCase
     public static function diagnosticControlByteProvider(): array
     {
         return [
-            'nul expression' => ["{bad\x00}", [], '"{bad\x00}"', "\x00"],
+            'nul expression' => ["{bad\x00}", [], '{bad\x00}', "\x00"],
             'esc map key' => ['{?x*}', ['x' => ["red\x1B[31m" => new \stdClass()]], 'variable "x[red\x1B[31m]"', "\x1B"],
             'del map key' => ['{?x*}', ['x' => ["gone\x7F" => new \stdClass()]], 'variable "x[gone\x7F]"', "\x7F"],
+            'u+0080 expression' => ["{bad\u{0080}}", [], '{bad\x80}', "\u{0080}"],
+            'u+009b map key' => ['{?x*}', ['x' => ["key\u{009B}" => new \stdClass()]], 'variable "x[key\x9B]"', "\u{009B}"],
+            'c1 before malformed byte' => ["{bad\u{009B}\xFF}", [], '{bad\xC2\x9B\xFF}', "\u{009B}"],
         ];
     }
 


### PR DESCRIPTION
URI Template 2 already renders ASCII controls and malformed UTF-8 visibly in syntax diagnostics, but valid C1 controls remain embedded. This aligns its private diagnostic escaper with the PSR-7 policy by covering C0, DEL, and C1 and using deterministic bytewise fallback whenever Unicode-aware replacement cannot be used. Template and variable values remain unchanged, and no public API or dependency is added.