### PR TITLE
Fix URI template prefix byte loss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to `uri-template` will be documented in this file.
 
 Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) principles.
 
+## v1.0.10 - Unreleased
+
+### Fixed
+
+- Fixed prefix modifiers counting Unicode code points and pct-encoded characters instead of bytes
+
 ## v1.0.9 - 2026-07-08
 
 ### Changed

--- a/src/UriTemplate.php
+++ b/src/UriTemplate.php
@@ -151,7 +151,7 @@ final class UriTemplate
                 $variable = self::stringifyValue($variable);
 
                 if ($value['modifier'] === ':' && isset($value['position'])) {
-                    $variable = \substr($variable, 0, $value['position']);
+                    $variable = self::prefixValue($variable, $value['position']);
                 }
                 $expanded = self::encodeValue($variable, $allowReserved);
             }
@@ -271,6 +271,92 @@ final class UriTemplate
         }
 
         return $value;
+    }
+
+    /**
+     * Select a prefix by Unicode code points and pct-encoded characters.
+     *
+     * Malformed bytes continue to count individually.
+     */
+    private static function prefixValue(string $value, int $length): string
+    {
+        if ($length < 1) {
+            return \substr($value, 0, $length);
+        }
+
+        $valueLength = \strlen($value);
+        if ($valueLength <= $length) {
+            return $value;
+        }
+
+        $offset = 0;
+
+        for ($taken = 0; $taken < $length && $offset < $valueLength; ++$taken) {
+            $offset += self::prefixCharacterByteLength($value, $offset, $valueLength);
+        }
+
+        return \substr($value, 0, $offset);
+    }
+
+    private static function prefixCharacterByteLength(string $value, int $offset, int $valueLength): int
+    {
+        if ($value[$offset] === '%' && $offset + 2 < $valueLength && \strspn($value, '0123456789ABCDEFabcdef', $offset + 1, 2) === 2) {
+            $lead = (int) \hexdec(\substr($value, $offset + 1, 2));
+            $octets = self::utf8SequenceByteLength($lead);
+
+            if ($octets === 1) {
+                return 3;
+            }
+
+            $candidate = \chr($lead);
+
+            for ($index = 1; $index < $octets; ++$index) {
+                $tripletOffset = $offset + 3 * $index;
+
+                if ($tripletOffset + 2 >= $valueLength || $value[$tripletOffset] !== '%' || \strspn($value, '0123456789ABCDEFabcdef', $tripletOffset + 1, 2) !== 2) {
+                    return 3;
+                }
+
+                $candidate .= \chr((int) \hexdec(\substr($value, $tripletOffset + 1, 2)));
+            }
+
+            return self::isSingleUtf8CodePoint($candidate) ? 3 * $octets : 3;
+        }
+
+        $octets = self::utf8SequenceByteLength(\ord($value[$offset]));
+        if ($octets === 1 || $offset + $octets > $valueLength) {
+            return 1;
+        }
+
+        return self::isSingleUtf8CodePoint(\substr($value, $offset, $octets)) ? $octets : 1;
+    }
+
+    private static function utf8SequenceByteLength(int $lead): int
+    {
+        if ($lead >= 0xC2 && $lead <= 0xDF) {
+            return 2;
+        }
+
+        if ($lead >= 0xE0 && $lead <= 0xEF) {
+            return 3;
+        }
+
+        return $lead >= 0xF0 && $lead <= 0xF4 ? 4 : 1;
+    }
+
+    private static function isSingleUtf8CodePoint(string $candidate): bool
+    {
+        $result = \preg_match('/\A.\z/us', $candidate);
+
+        if ($result !== false) {
+            return $result === 1;
+        }
+
+        if (\preg_last_error() === \PREG_BAD_UTF8_ERROR) {
+            return false;
+        }
+
+        throw new \RuntimeException(\sprintf('Unable to process template: %s', \preg_last_error_msg()));
     }
 
     private static function encodeValue(string $value, bool $allowReserved): string

--- a/tests/UriTemplateTest.php
+++ b/tests/UriTemplateTest.php
@@ -136,6 +136,31 @@ final class UriTemplateTest extends TestCase
         self::assertSame($expansion, UriTemplate::expand($template, $variables));
     }
 
+    public static function prefixProvider(): array
+    {
+        return [
+            'unicode code point' => ['{var:1}', ['var' => "\xC3\xA9clair"], '%C3%A9'],
+            'unicode code point and ASCII' => ['{var:2}', ['var' => "\xC3\xA9clair"], '%C3%A9c'],
+            'simple pct triplet' => ['{var:1}', ['var' => '%2Fabc'], '%252F'],
+            'reserved pct triplet' => ['{+var:1}', ['var' => '%2Fabc'], '%2F'],
+            'two-octet pct code point' => ['{+var:1}', ['var' => '%C3%A9clair'], '%C3%A9'],
+            'three-octet pct code point' => ['{+var:1}', ['var' => '%E2%82%ACuro'], '%E2%82%AC'],
+            'four-octet pct code point and ASCII' => ['{+var:2}', ['var' => '%F0%9F%92%A9rest'], '%F0%9F%92%A9r'],
+            'incomplete pct code point' => ['{+var:2}', ['var' => '%C3xyz'], '%C3x'],
+            'invalid UTF-8 byte fallback' => ['{var:1}', ['var' => "\xC3abc"], '%C3'],
+            'pct code point before malformed tail' => ['{+var:1}', ['var' => "%C3%A9clair\xFF"], '%C3%A9'],
+            'malformed byte before raw code point' => ['{var:2}', ['var' => "\xFF\xC3\xA9rest"], '%FF%C3%A9'],
+        ];
+    }
+
+    /**
+     * @dataProvider prefixProvider
+     */
+    public function testCountsPrefixCharacters(string $template, array $variables, string $expansion): void
+    {
+        self::assertSame($expansion, UriTemplate::expand($template, $variables));
+    }
+
     public static function nonFiniteFloatProvider(): array
     {
         return [


### PR DESCRIPTION
URI Template 1.x truncates prefix modifiers by bytes, which can split raw UTF-8 and existing percent-encoded characters and omit part of the requested prefix. This changes only prefix selection to scan the requested prefix by Unicode code points and complete percent-encoded UTF-8 sequences, while malformed bytes continue to count individually and invalid non-positive lengths retain their existing behavior. Broader URI Template 2 validation and diagnostic behavior are not backported.